### PR TITLE
Add browser desktop notifications on transcription completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# Meeting Transcriber
+
+Audio transcription web app using WhisperX + PyAnnote for speaker diarization.
+
+## Tech Stack
+
+- **Backend:** FastAPI (Python), Uvicorn, Pydantic
+- **Frontend:** Vanilla JavaScript SPA (no framework)
+- **Transcription:** WhisperX (large-v3), PyAnnote (speaker diarization)
+- **Storage:** File-based (JSON metadata + audio files, no database)
+- **Job system:** In-memory dict with threading (no Celery/Redis)
+
+## Project Structure
+
+```
+backend/
+  main.py              # FastAPI app, mounts routers + serves SPA
+  schemas.py           # Pydantic models (MeetingMetadata, JobInfo, Transcript, etc.)
+  routers/
+    meetings.py        # CRUD + upload + audio streaming + retry
+    jobs.py            # GET /api/jobs/{job_id}
+    analysis.py        # GET /api/templates/{type}
+  services/
+    transcriber.py     # Background thread transcription (_run_transcription)
+    job_queue.py       # In-memory JobQueue with thread lock
+frontend/
+  index.html           # SPA shell, loads all JS/CSS
+  css/styles.css       # All styles, dark/light theme via CSS vars
+  js/
+    app.js             # Client-side router (/, /upload, /meetings/{id})
+    api.js             # Fetch wrapper for all API calls
+    utils.js           # Formatters, toast, clipboard, speaker colors, escapeHtml
+    components/
+      meeting-list.js      # List view with status badges
+      upload.js            # Drag-drop upload form
+      transcript-viewer.js # Audio player, segments, tabs, polling, progress
+      speaker-editor.js    # Popover for renaming speakers
+      analysis-viewer.js   # LLM prompt generation from templates
+config.py              # Env vars: HF_TOKEN, WHISPER_MODEL, DATA_DIR, etc.
+run.py                 # Uvicorn entry point (port 8000, reload=True)
+transcriber.py         # Standalone CLI transcription script
+templates/             # Analysis prompt templates (interview, sales, client, other)
+data/meetings/{id}/    # Per-meeting: metadata.json, transcript.json, audio file
+```
+
+## Key Flows
+
+**Transcription pipeline:** Upload (POST /api/meetings) -> save audio + metadata.json (status=PROCESSING) -> create JobInfo -> spawn daemon thread -> WhisperX transcribe -> align timestamps -> PyAnnote diarize -> save transcript.json -> update metadata (status=READY)
+
+**Frontend polling:** transcript-viewer.js polls GET /api/jobs/{jobId} every 3s -> shows progress bar -> auto-navigates on completion
+
+**Job states:** PENDING -> PROCESSING -> COMPLETED|FAILED
+**Meeting states:** PROCESSING -> READY|ERROR
+
+## API Endpoints
+
+- `GET /api/meetings` - List all (sorted by date desc)
+- `POST /api/meetings` - Upload + start transcription (multipart form)
+- `GET /api/meetings/{id}` - Meeting detail with transcript
+- `PATCH /api/meetings/{id}` - Update title/type/speakers
+- `PATCH /api/meetings/{id}/segments/speaker` - Rename single segment speaker
+- `POST /api/meetings/{id}/retry` - Retry failed transcription
+- `DELETE /api/meetings/{id}` - Delete meeting + files
+- `GET /api/meetings/{id}/audio` - Stream audio file
+- `GET /api/jobs/{jobId}` - Job progress/status
+- `GET /api/templates/{type}` - Analysis prompt template
+
+## Configuration (env vars)
+
+- `HF_TOKEN` - HuggingFace token (required for diarization)
+- `WHISPER_MODEL` - Model size (default: large-v3)
+- `WHISPER_DEVICE` - Device (default: auto -> cuda or cpu)
+- `WHISPER_BATCH_SIZE` - Batch size (default: 16)
+- `DATA_DIR` - Data storage path (default: ./data)
+- `MAX_UPLOAD_SIZE` - Max file size (default: 500MB)
+
+## Frontend Patterns
+
+- All JS is global (no modules/bundler), loaded via script tags in index.html
+- State shared via globals: `currentAudio`, `pollInterval`, `autoScroll`, `window._speakerEditorState`
+- Toast notifications via `showToast(message, type)`
+- Theme toggle persisted in localStorage
+- Recent speaker names persisted in localStorage
+- No notification system currently exists

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ make run
 
 Open http://localhost:8000 in your browser. You can now upload audio/video files and start transcribing.
 
+> **Use `localhost`, not `0.0.0.0`.** Some browser features like desktop notifications require a secure context. Chrome treats `localhost` as secure, but not `0.0.0.0`.
+
 ## Web App
 
 The web app lets you upload recordings, track transcription progress, view transcripts synchronized with audio playback, and generate LLM-ready prompts for analysis.
@@ -104,6 +106,7 @@ The web app lets you upload recordings, track transcription progress, view trans
 - **Playback speed** control (0.5x to 2x)
 - **Speaker renaming** -- click a speaker label to assign a real name; recent names are remembered
 - **LLM-ready analysis prompts** -- pick a template (interview, sales, client, general), and the app combines it with your transcript into a prompt you can paste into any LLM
+- **Desktop notifications** -- get a browser notification when transcription finishes (or fails), even if the tab is in the background
 - **Retry** failed transcriptions
 
 ### Upload Options

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -276,12 +276,20 @@ async function updateProgress(meetingId, jobId) {
 
         if (job.status === 'completed') {
             clearInterval(pollInterval);
+            sendNotification('Transcription complete', {
+                body: 'Your meeting has been transcribed and is ready to view.',
+                url: `/meetings/${meetingId}`,
+            });
             App.navigate(`/meetings/${meetingId}`);
             return;
         }
 
         if (job.status === 'failed') {
             clearInterval(pollInterval);
+            sendNotification('Transcription failed', {
+                body: job.error || 'An error occurred during transcription.',
+                url: `/meetings/${meetingId}`,
+            });
             section.innerHTML = `
                 <div class="error-state">
                     Transcription failed: ${escapeHtml(job.error || 'Unknown error')}

--- a/frontend/js/components/upload.js
+++ b/frontend/js/components/upload.js
@@ -141,6 +141,7 @@ async function handleUpload(e) {
         const language = document.getElementById('language-select').value;
         const numSpeakers = document.getElementById('speakers-input').value.trim() || 'auto';
         const result = await API.createMeeting(selectedFile, title, type, language, numSpeakers);
+        requestNotificationPermission();
         App.navigate(`/meetings/${result.meeting_id}`);
     } catch (err) {
         showToast(err.message, 'error');

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -91,3 +91,23 @@ function escapeHtml(str) {
     div.textContent = str;
     return div.innerHTML;
 }
+
+/* Browser Notifications */
+
+function requestNotificationPermission() {
+    if ('Notification' in window && Notification.permission === 'default') {
+        Notification.requestPermission();
+    }
+}
+
+function sendNotification(title, options = {}) {
+    if (!('Notification' in window) || Notification.permission !== 'granted') return;
+    if (document.visibilityState === 'visible') return;
+
+    const notification = new Notification(title, options);
+    notification.addEventListener('click', () => {
+        window.focus();
+        if (options.url) App.navigate(options.url);
+        notification.close();
+    });
+}


### PR DESCRIPTION
## Summary

- Adds Web Notifications API support to alert users when a transcription completes or fails, even if the browser tab is in the background
- Permission is requested at upload time for a natural UX flow
- Clicking the notification focuses the window and navigates to the meeting
- Also adds `CLAUDE.md` with project documentation for AI context

## Test plan

- [x] Upload an audio file, switch to another tab, and verify a desktop notification appears when transcription completes
- [x] Verify no notification appears if the tab is in the foreground
- [x] Trigger a transcription failure and verify the failure notification shows the error message
- [x] Verify clicking the notification focuses the window and navigates to the meeting
- [x] Verify the browser permission prompt appears after the first upload
- [x] Verify no permission prompt appears if already granted or denied