### PR TITLE
Use localhost instead of 0.0.0.0 for dev server

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,4 +2,4 @@
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("backend.main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("backend.main:app", host="localhost", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- Change dev server host from `0.0.0.0` to `localhost` so Uvicorn displays `http://localhost:8000` on startup
- Chrome treats `localhost` as a secure context, which is required for the Notification API used by desktop notifications

## Test plan
- [ ] Run `python run.py` and verify the server URL shows `http://localhost:8000`
- [ ] Verify desktop notifications work when a transcription completes