### PR TITLE
Add Prototype Scope analysis template

### DIFF
--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -9,6 +9,7 @@ TEMPLATE_FILES = {
     "sales": "sales_meeting_analysis.md",
     "client": "client_meeting_analysis.md",
     "other": "other.md",
+    "prototype": "prototype_scope.md",
 }
 
 

--- a/docs/plans/8-prototype-scope-template.md
+++ b/docs/plans/8-prototype-scope-template.md
@@ -1,0 +1,57 @@
+# Plan: Prototype Scope Template
+
+**Story**: GitHub Issue #8
+**Spec**: docs/specs/prototype-scope-template.md
+**Branch**: feature/prototype-scope-template
+**Date**: 2026-03-10
+**Mode**: Standard — no test infrastructure exists; change is 3 files with minimal logic
+
+## Technical Decisions
+
+### TD-1: Template available for all meeting types without auto-select
+- **Context**: The template must appear for all meeting types (BR-1)
+- **Decision**: Add it as a regular dropdown option without any `selected` logic tied to meeting type
+- **Alternatives considered**: Auto-selecting based on meeting type — unnecessary since this is a cross-cutting template
+
+## Files to Create or Modify
+
+- `templates/prototype_scope.md` — New LLM prompt template with all 8 required sections
+- `backend/routers/analysis.py` — Add `"prototype": "prototype_scope.md"` to TEMPLATE_FILES dict
+- `frontend/js/components/analysis-viewer.js` — Add Prototype Scope option to dropdown
+
+## Approach per AC
+
+### AC 1: Dropdown option appears for all meeting types
+Add `<option value="prototype">Prototype Scope</option>` to the select element (not conditioned on meetingType).
+
+### AC 2: Structured output with required sections
+Template prompt instructs LLM to produce: Project Overview, Brand & Visual Direction, Pages & Navigation, Core Features (5-7), Sample Data & Content, User Flows, Non-Goals, Build Phases.
+
+### AC 3-4: Real content extraction and priority-based features
+Template prompt contains explicit instructions to extract real content and prioritize by client emphasis.
+
+### AC 5: Insufficient detail handling
+Template prompt includes fallback instruction for when transcript lacks product/feature discussion.
+
+### AC 6: Thai/mixed language → English
+Template prompt includes language instruction.
+
+### AC 7: Copy-paste ready for AI coding tools
+Output format designed as structured markdown ready for Replit Agent / similar tools.
+
+## Commit Sequence
+
+1. Add prototype scope template file
+2. Wire template in backend and frontend
+
+## Risks and Trade-offs
+
+- None — follows the exact pattern of 4 existing templates
+
+## Deviations from Spec
+
+- None anticipated
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/docs/specs/prototype-scope-template.md
+++ b/docs/specs/prototype-scope-template.md
@@ -1,0 +1,74 @@
+# Prototype Scope Template
+
+## Overview
+
+### Problem
+
+After sales or client meetings, Nimble's team builds rapid prototypes using AI coding tools (Replit Agent, Lovable, Bolt) to demonstrate what a solution could look like. Today, translating a meeting conversation into a well-structured prompt for these tools is manual and inconsistent. Key details from the conversation — client terminology, product names, priorities, visual references — are often lost or forgotten.
+
+### Goals
+
+- Generate a structured, AI-coding-tool-optimized document from a meeting transcript that can be directly pasted into Replit Agent (or similar) to produce a prototype
+- Extract real content from the conversation (client's products, branding, terminology) so the prototype feels tailored, not generic
+- Reflect the client's stated priorities so the prototype focuses on what matters most to them
+
+### Scope
+
+Add a new "Prototype Scope" template to the existing analysis template system. No changes to the analysis workflow, UI patterns, or backend architecture.
+
+## User Stories
+
+- As a user, I can select "Prototype Scope" from the analysis template dropdown so that I can generate a prototype-ready prompt from any meeting transcript
+- As a user, I get a structured document that I can paste directly into Replit Agent or a similar AI coding tool to build a prototype
+- As a user, the generated prompt extracts real content from the conversation (product names, branding, client terminology) so the prototype feels personalized
+- As a user, the generated prompt reflects priorities discussed in the meeting so the prototype focuses on what the client cares about most
+
+## Business Rules
+
+| ID | Rule | Rationale |
+|----|------|-----------|
+| BR-1 | The template must be available regardless of meeting type (sales, client, interview, other) | Prototype scoping can follow any type of meeting |
+| BR-2 | The generated output must be structured in build phases (foundation, core feature, polish) | AI coding tools produce better results with iterative, phased prompts rather than monolithic ones |
+| BR-3 | The output must instruct the LLM to extract real content from the transcript (product names, pricing, categories, brand language) rather than using placeholder text | Prototypes with targeted content are significantly more impactful to clients |
+| BR-4 | The output must instruct the LLM to identify and prioritize features based on what the client emphasized or described as high priority | The prototype should demonstrate what the client cares about, not what's easiest to build |
+| BR-5 | The output must include explicit non-goals/out-of-scope items | AI coding tools cannot infer boundaries from omission and will add unnecessary features otherwise |
+
+## Data Requirements
+
+### New Template File
+
+A new markdown template file (`templates/prototype_scope.md`) containing the LLM prompt. The prompt instructs the LLM to analyze the transcript and produce output with these sections:
+
+1. **Project Overview** — App name (derived from client's product/service), one-line description, target user, core problem
+2. **Brand & Visual Direction** — Colors, visual style, reference sites/competitors mentioned in the call
+3. **Pages & Navigation** — Each page with purpose and key components, navigation structure
+4. **Core Features** (max 5-7, prioritized) — Feature name, description, acceptance criteria, using the client's terminology
+5. **Sample Data & Content** — Real product/service names, categories, pricing, descriptions, and workflows extracted from the conversation
+6. **User Flows** (2-3 primary journeys) — Step-by-step with page references
+7. **Non-Goals / Out of Scope** — What the prototype does NOT include (e.g., real auth, payment processing, backend APIs)
+8. **Build Phases** — Phase 1: Foundation (layout, nav, branding, landing page), Phase 2: Primary feature with sample data, Phase 3: Secondary features and polish. Each phase self-contained enough to be used as a single prompt
+
+### Backend Wiring
+
+- Add entry to `TEMPLATE_FILES` dict in `backend/routers/analysis.py`
+- Template key: `"prototype"`
+
+### Frontend Wiring
+
+- Add `<option value="prototype">Prototype Scope</option>` to the template dropdown in `frontend/js/components/analysis-viewer.js`
+
+## Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Meeting transcript has no clear product/feature discussion | The LLM should note that insufficient detail was found and list what additional information is needed |
+| Client mentioned many features with no clear prioritization | The LLM should infer priority from conversation signals (time spent discussing, enthusiasm, "must-have" language) and state its reasoning |
+| Conversation is in Thai or mixed English/Thai | The generated prototype scope should be in English regardless of transcript language |
+| Very short transcript (few segments) | The LLM should produce what it can and explicitly flag gaps |
+
+## Open Questions
+
+| ID | Question | Impact |
+|----|----------|--------|
+| OQ-1 | Should the template output be in a specific markdown format that works best with Replit's "Improve Prompt" feature, or is plain structured markdown sufficient? | May affect template wording |
+| OQ-2 | Should the build phases include estimated complexity hints (e.g., "this phase should take ~1 prompt iteration")? | Useful for less experienced prototype builders but may be misleading |

--- a/frontend/js/components/analysis-viewer.js
+++ b/frontend/js/components/analysis-viewer.js
@@ -9,6 +9,7 @@ function renderAnalysisTab(container, meetingId, meetingType) {
                     <option value="sales" ${meetingType === 'sales' ? 'selected' : ''}>Sales</option>
                     <option value="client" ${meetingType === 'client' ? 'selected' : ''}>Client</option>
                     <option value="other" ${meetingType === 'other' ? 'selected' : ''}>Other</option>
+                    <option value="prototype">Prototype Scope</option>
                 </select>
             </div>
             <button class="btn btn-primary" id="generate-prompt-btn" onclick="handleGeneratePrompt()">

--- a/templates/prototype_scope.md
+++ b/templates/prototype_scope.md
@@ -1,0 +1,122 @@
+# Prototype Scope Template
+
+Use this prompt with a meeting transcript to generate a structured prototype scope document that can be pasted directly into an AI coding tool (Replit Agent, Lovable, Bolt, etc.).
+
+## Prompt
+
+You are analyzing a meeting transcript to produce a **prototype scope document**. This document will be pasted directly into an AI coding tool to build a working prototype.
+
+**Important instructions:**
+- Extract **real content** from the transcript: product names, pricing, categories, brand language, terminology the client actually used. Do NOT use generic placeholders like "Product A" or "Lorem ipsum."
+- Prioritize features based on what the client **emphasized** in the conversation — look for signals like time spent discussing, enthusiasm, "must-have" language, and repeated mentions.
+- If the transcript is in Thai or mixed English/Thai, produce the output **entirely in English**.
+- If the transcript lacks sufficient product or feature discussion, clearly state what information is missing and list what additional details are needed to produce a complete scope.
+
+### Output Format
+
+Produce the following sections in markdown:
+
+```markdown
+# [App/Product Name — derived from client's product or service]
+
+> One-line description of what this prototype demonstrates.
+
+**Target User:** [Who will use this — extracted from conversation]
+**Core Problem:** [What problem this solves — in the client's own words where possible]
+
+## Brand & Visual Direction
+
+- **Colors:** [Any colors, palettes, or visual preferences mentioned]
+- **Style:** [Modern, minimal, playful, corporate — based on conversation cues]
+- **References:** [Any websites, competitors, or visual references the client mentioned]
+- **Logo/Branding:** [Any brand assets or guidelines discussed]
+
+## Pages & Navigation
+
+| Page | Purpose | Key Components |
+|------|---------|----------------|
+| [Page name] | [What this page does] | [Main UI elements] |
+
+**Navigation:** [Describe the navigation structure — sidebar, top nav, tabs, etc.]
+
+## Core Features (prioritized)
+
+> Ordered by client priority — features the client emphasized most are listed first.
+
+### 1. [Feature Name — using client's terminology]
+- **Description:** [What it does]
+- **Why prioritized:** [What signals from the conversation indicate this matters most]
+- **Key behaviors:** [Acceptance criteria in plain language]
+
+### 2. [Feature Name]
+...
+
+(Maximum 5-7 features)
+
+## Sample Data & Content
+
+Use this real data extracted from the conversation to populate the prototype:
+
+### [Category — e.g., Products, Services, Menu Items]
+| Name | Description | Price/Details |
+|------|-------------|---------------|
+| [Real name from transcript] | [Real description] | [Real pricing if mentioned] |
+
+### [Additional categories as needed]
+...
+
+## User Flows
+
+### Flow 1: [Primary user journey name]
+1. User lands on [page]
+2. User [action] → sees [result]
+3. ...
+
+### Flow 2: [Secondary journey]
+...
+
+(2-3 primary flows)
+
+## Non-Goals / Out of Scope
+
+This prototype does NOT include:
+- [e.g., Real authentication — use mock login]
+- [e.g., Payment processing — show UI only, no real transactions]
+- [e.g., Backend API — all data is hardcoded/mocked]
+- [List items based on what was discussed as future work or explicitly excluded]
+
+## Build Phases
+
+### Phase 1: Foundation
+> Layout, navigation, branding, and landing page.
+
+Set up the app with:
+- [App framework/structure based on pages listed above]
+- Navigation: [structure from Pages section]
+- Brand styling: [colors, fonts, style from Brand section]
+- Landing/home page with [key elements]
+- Use [real brand language and content from transcript]
+
+### Phase 2: Core Feature + Sample Data
+> Build the primary feature with real content.
+
+Implement:
+- [#1 priority feature from Core Features]
+- Populate with sample data from the Sample Data section
+- [Key user flow from User Flows]
+- [Any secondary feature tightly coupled to the primary one]
+
+### Phase 3: Secondary Features & Polish
+> Remaining features and refinements.
+
+Add:
+- [Remaining features from Core Features list]
+- [Secondary user flows]
+- Responsive design adjustments
+- Empty states and loading states
+- [Any polish items mentioned in conversation]
+```
+
+## Transcript
+
+[PASTE TRANSCRIPT HERE]


### PR DESCRIPTION
Story: https://github.com/nimblehq/audio-transcriber/issues/8

## Summary

Add a new "Prototype Scope" template to the analysis system that generates structured, AI-coding-tool-ready documents from meeting transcripts. The template extracts real content (product names, pricing, brand language) from the conversation and organizes it into build phases suitable for tools like Replit Agent, Lovable, or Bolt.

## Approach

Follows the existing template pattern exactly — new template file + one-line additions to backend routing dict and frontend dropdown. No changes to the analysis workflow, UI patterns, or backend architecture.

- `templates/prototype_scope.md` — LLM prompt with 8 sections: Project Overview, Brand & Visual Direction, Pages & Navigation, Core Features, Sample Data, User Flows, Non-Goals, Build Phases
- `backend/routers/analysis.py` — Register `"prototype"` key
- `frontend/js/components/analysis-viewer.js` — Add dropdown option

## Verification

- Verified template file uses `[PASTE TRANSCRIPT HERE]` placeholder matching the frontend substitution logic
- Verified backend routing key `"prototype"` maps to correct filename `"prototype_scope.md"`
- Verified dropdown option appears after existing options and is not auto-selected for any meeting type (available for all types per BR-1)