### PR TITLE
Add Ruff linting and formatting setup

### DIFF
--- a/.argus/codebase/CONVENTIONS.md
+++ b/.argus/codebase/CONVENTIONS.md
@@ -22,7 +22,7 @@
 ## Project Conventions
 
 - **No build step** — no transpilation, bundling, or minification
-- **No linter/formatter** — no ESLint, Prettier, Black, or Ruff configured
+- **Linter/Formatter:** Ruff (`ruff check` + `ruff format`) for Python, configured in `pyproject.toml`. No frontend linter/formatter
 - **No type checking** — no mypy or TypeScript
 - **Git:** Gitflow branching model, `develop` as main branch
 - **Commits:** Conventional-style commit messages

--- a/.argus/config.yml
+++ b/.argus/config.yml
@@ -2,14 +2,18 @@
 # Docs: https://github.com/nimblehq/argus/blob/main/docs/framework.md#configuration
 
 # PM Tool
-pm_tool: github_projects
-commit_prefix: gh
-github_project_number: 92
+pm_tool: github_issues
+commit_prefix: ghi
+github_issue_types_supported: false
 # github_repo: owner/repo  # Optional — auto-detected from git remote origin
+# github_toolsets:          # Default: [issues, users]
+#   - issues
+#   - users
 
 
 # Stack & Conventions
 stacks:
+  - javascript
   - python
 # conventions_source: https://nimblehq.co/compass/development/code-conventions/
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,10 @@
-from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
 from pathlib import Path
 
-from backend.routers import meetings, jobs, analysis
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from backend.routers import analysis, jobs, meetings
 
 app = FastAPI(title="Meeting Transcriber")
 

--- a/backend/routers/meetings.py
+++ b/backend/routers/meetings.py
@@ -56,14 +56,16 @@ async def list_meetings():
         try:
             with open(meta_path) as f:
                 meta = MeetingMetadata(**json.load(f))
-            meetings.append(MeetingSummary(
-                id=meta.id,
-                title=meta.title,
-                type=meta.type,
-                created_at=meta.created_at,
-                duration_seconds=meta.duration_seconds,
-                status=meta.status,
-            ))
+            meetings.append(
+                MeetingSummary(
+                    id=meta.id,
+                    title=meta.title,
+                    type=meta.type,
+                    created_at=meta.created_at,
+                    duration_seconds=meta.duration_seconds,
+                    status=meta.status,
+                )
+            )
         except Exception:
             continue
 
@@ -200,9 +202,7 @@ async def update_segment_speaker(meeting_id: str, update: SegmentSpeakerUpdate):
     segment.speaker = new_speaker_id
 
     # Save updated transcript
-    transcript_path.write_text(
-        json.dumps(transcript.model_dump(), ensure_ascii=False, indent=2)
-    )
+    transcript_path.write_text(json.dumps(transcript.model_dump(), ensure_ascii=False, indent=2))
 
     # Map the new speaker ID to the given name
     metadata.speakers[new_speaker_id] = update.speaker_name

--- a/backend/routers/meetings.py
+++ b/backend/routers/meetings.py
@@ -5,8 +5,8 @@ import shutil
 import uuid
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, UploadFile, File, Form
-from fastapi.responses import FileResponse, Response
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse
 
 from backend.schemas import (
     MeetingDetail,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -94,5 +94,3 @@ class JobInfo(BaseModel):
 class SegmentSpeakerUpdate(BaseModel):
     segment_id: str
     speaker_name: str
-
-

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import threading
-from pathlib import Path
 
 from backend.schemas import JobStatus, MeetingMetadata, MeetingStatus
 from backend.services.job_queue import job_queue
@@ -42,8 +41,9 @@ def _run_transcription(meeting_id: str, job_id: str):
         warnings.filterwarnings("ignore", message="Model was trained with")
         warnings.filterwarnings("ignore", message="torchaudio._backend.list_audio_backends")
 
-        import torch
         import functools
+
+        import torch
 
         # PyTorch 2.6+ compat patch
         _original_torch_load = torch.load

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -16,6 +16,7 @@ def _get_device() -> str:
         return WHISPER_DEVICE
     try:
         import torch
+
         if torch.cuda.is_available():
             return "cuda"
     except ImportError:
@@ -38,6 +39,7 @@ def _run_transcription(meeting_id: str, job_id: str):
 
         # Import heavy deps only when needed
         import warnings
+
         warnings.filterwarnings("ignore", message="Model was trained with")
         warnings.filterwarnings("ignore", message="torchaudio._backend.list_audio_backends")
 
@@ -50,7 +52,7 @@ def _run_transcription(meeting_id: str, job_id: str):
 
         @functools.wraps(_original_torch_load)
         def _patched_torch_load(*args, **kwargs):
-            kwargs['weights_only'] = False
+            kwargs["weights_only"] = False
             return _original_torch_load(*args, **kwargs)
 
         torch.load = _patched_torch_load
@@ -84,18 +86,46 @@ def _run_transcription(meeting_id: str, job_id: str):
 
         # Align
         ALIGNMENT_LANGUAGES = {
-            "en", "fr", "de", "es", "it", "ja", "zh", "nl", "uk", "pt",
-            "ar", "cs", "ru", "pl", "hu", "fi", "fa", "el", "tr", "da",
-            "he", "vi", "ko", "ur", "te", "hi", "ta", "id", "ms"
+            "en",
+            "fr",
+            "de",
+            "es",
+            "it",
+            "ja",
+            "zh",
+            "nl",
+            "uk",
+            "pt",
+            "ar",
+            "cs",
+            "ru",
+            "pl",
+            "hu",
+            "fi",
+            "fa",
+            "el",
+            "tr",
+            "da",
+            "he",
+            "vi",
+            "ko",
+            "ur",
+            "te",
+            "hi",
+            "ta",
+            "id",
+            "ms",
         }
 
         if detected_language in ALIGNMENT_LANGUAGES:
             job_queue.update_job(job_id, stage="aligning", progress=50)
-            model_a, align_metadata = whisperx.load_align_model(
-                language_code=detected_language, device=device
-            )
+            model_a, align_metadata = whisperx.load_align_model(language_code=detected_language, device=device)
             result = whisperx.align(
-                result["segments"], model_a, align_metadata, audio, device,
+                result["segments"],
+                model_a,
+                align_metadata,
+                audio,
+                device,
                 return_char_alignments=False,
             )
             del model_a
@@ -121,13 +151,15 @@ def _run_transcription(meeting_id: str, job_id: str):
         # Build transcript
         segments = []
         for i, seg in enumerate(result["segments"]):
-            segments.append({
-                "id": f"seg_{i:04d}",
-                "start": round(seg["start"], 2),
-                "end": round(seg["end"], 2),
-                "speaker": seg.get("speaker", "UNKNOWN"),
-                "text": seg["text"].strip(),
-            })
+            segments.append(
+                {
+                    "id": f"seg_{i:04d}",
+                    "start": round(seg["start"], 2),
+                    "end": round(seg["end"], 2),
+                    "speaker": seg.get("speaker", "UNKNOWN"),
+                    "text": seg["text"].strip(),
+                }
+            )
 
         transcript = {
             "segments": segments,

--- a/docs/plans/23-ruff-linting-setup.md
+++ b/docs/plans/23-ruff-linting-setup.md
@@ -1,0 +1,54 @@
+# Plan: As a developer, I can run Ruff to check and format code so that style is consistent
+
+**Story**: #23
+**Spec**: docs/specs/test-framework-setup.md (US5)
+**Branch**: feature/23-ruff-linting-setup
+**Date**: 2026-03-14
+**Mode**: Standard — tooling config, no business logic to TDD
+
+## Technical Decisions
+
+### TD-1: Line length 120
+- **Context**: Need a line length that fits the project's existing style
+- **Decision**: 120 characters — wide enough for FastAPI decorators and Pydantic fields
+- **Alternatives considered**: 88 (Ruff default), 100, 79 (PEP 8 strict)
+
+### TD-2: Double quotes
+- **Context**: Need consistent quote style
+- **Decision**: Double quotes (Ruff default, matches existing code)
+- **Alternatives considered**: Single quotes
+
+## Files to Create or Modify
+
+- `requirements-dev.txt` — add ruff dependency
+- `pyproject.toml` — add Ruff configuration sections
+- `backend/**/*.py`, `config.py`, `run.py`, `transcriber.py`, `tests/**/*.py` — fix violations
+
+## Approach per AC
+
+### AC 1: Ruff added as a dev dependency
+Add `ruff>=0.9.0` to `requirements-dev.txt` and install.
+
+### AC 2: pyproject.toml contains Ruff config
+Add `[tool.ruff]`, `[tool.ruff.lint]`, and `[tool.ruff.format]` sections.
+
+### AC 3 & 4: All existing code passes, violations fixed
+Run `ruff check --fix .` and `ruff format .` to auto-fix, then manually fix remaining issues.
+
+## Commit Sequence
+
+1. Add Ruff config and dev dependency
+2. Fix linting violations
+3. Fix formatting violations
+
+## Risks and Trade-offs
+
+- Import reordering (I rules) is safe but may produce a noisy diff
+
+## Deviations from Spec
+
+- None anticipated
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/docs/specs/transcription-failure-recovery.md
+++ b/docs/specs/transcription-failure-recovery.md
@@ -1,0 +1,75 @@
+# Transcription Failure Recovery
+
+## Problem
+
+When transcription fails or gets stuck, meetings remain in PROCESSING status permanently. Users must delete the meeting and re-upload the audio file, losing any metadata (title, type, speaker names) they already entered. This is the top user friction point.
+
+### Root Causes
+
+1. **Stuck PROCESSING state** — If the transcription thread hangs or dies without raising an exception, the meeting status never transitions to ERROR. The retry button only appears for ERROR status, so stuck meetings have no recovery path.
+2. **Job state lost on restart** — Job tracking is in-memory only. Restarting the app leaves PROCESSING meetings orphaned with no thread running.
+3. **No timeout** — Transcription threads can hang indefinitely with no watchdog.
+
+## Solution
+
+### F1: Detect and recover stuck transcriptions on startup
+
+On app startup, scan all meetings with PROCESSING status. Since job state is in-memory and lost on restart, any PROCESSING meeting at startup has no active thread — transition it to ERROR so the existing retry mechanism can handle it.
+
+**Acceptance criteria:**
+- On app startup, all meetings with status=PROCESSING are set to status=ERROR
+- These meetings show the retry button in the UI
+- Retrying a recovered meeting works end-to-end
+
+### F2: Manual unstuck from the UI
+
+Allow users to force a stuck PROCESSING meeting to ERROR state directly from the meeting detail view, without restarting the app.
+
+**Acceptance criteria:**
+- PROCESSING meetings show a "Cancel transcription" button after a reasonable delay (e.g., visible after 5 minutes, or always visible)
+- Clicking it sets the meeting status to ERROR and kills/abandons the transcription job
+- The retry button appears immediately after cancelling
+- Confirmation prompt before cancelling ("Are you sure? This will stop the current transcription.")
+
+### F3: Transcription timeout with error transition
+
+Add a configurable timeout (default: 30 minutes) for transcription jobs. If a transcription exceeds the timeout, mark the job as FAILED and the meeting as ERROR.
+
+**Acceptance criteria:**
+- Transcriptions that exceed the timeout are marked ERROR
+- Timeout is configurable via `TRANSCRIPTION_TIMEOUT` env var (default: 1800 seconds)
+- The retry button appears for timed-out meetings
+- Timeout value is logged when a transcription is killed
+
+### F4: Preserve metadata on retry
+
+When retrying a transcription, keep the existing meeting metadata (title, type, speaker names) intact. Only reset the status and job reference.
+
+**Acceptance criteria:**
+- Retrying a failed transcription preserves title, meeting_type, and speaker names
+- Only status and job_id fields are updated on retry
+- The audio file is not re-uploaded or duplicated
+
+### F5: Surface failure reason in the UI
+
+Ensure the meeting detail view shows the retry button for any meeting in ERROR state, with a message indicating what went wrong.
+
+**Acceptance criteria:**
+- ERROR meetings show a retry button (already exists, verify it works)
+- Error message indicates the failure reason when available (e.g., "Transcription timed out", "Transcription failed: {error}", "Transcription cancelled by user")
+- Meeting list shows ERROR status badge (not stuck on PROCESSING)
+
+## Out of Scope
+
+- Persistent job queue (Redis/database) — overkill for local single-user app
+- Automatic retry without user action
+- Model caching across jobs — not impactful for current usage pattern (~2-10 meetings/week)
+- Concurrent transcription limits — users rarely upload multiple files at once
+
+## Technical Notes
+
+- F1 implementation belongs in `backend/main.py` as a startup event/lifespan handler
+- F2 needs a new endpoint (e.g., `POST /api/meetings/{id}/cancel`) and a UI button in transcript-viewer.js
+- F3 can use `threading.Timer` or a simple timestamp check in the transcription thread
+- F4 requires auditing `retry_transcription()` in `backend/routers/meetings.py` to ensure it doesn't overwrite metadata fields
+- The existing retry endpoint and UI button are functional — the core issue is meetings never reaching ERROR state

--- a/docs/specs/transcription-quality-improvements.md
+++ b/docs/specs/transcription-quality-improvements.md
@@ -1,0 +1,146 @@
+# Transcription & Diarization Quality Improvements
+
+## Overview
+
+### Problem Statement
+
+The Meeting Transcriber is in daily use by Nimble's sales team, but transcription and diarization quality is a recurring pain point:
+
+- **Transcription errors:** Proper nouns, technical terms, and brand names are frequently misrecognized.
+- **Speaker merging:** Pyannote diarization sometimes collapses distinct speakers into one, even in small meetings (3-4 people).
+- **Thai language gaps:** Thai alignment is skipped entirely (no wav2vec2 model configured), reducing timestamp precision and downstream diarization accuracy for Thai and mixed-language recordings.
+- **Audio quality challenges:** Recordings come from Plaud devices or phone calls in large meeting rooms where the mic is often far from some speakers, introducing noise and low signal levels.
+
+### Goals
+
+1. Reduce word-level transcription errors, especially for proper nouns and technical terms.
+2. Reduce speaker merging errors in diarization.
+3. Add Thai language alignment support.
+4. Improve robustness to poor audio conditions (far-field mic, room noise).
+
+### Scope
+
+Backend transcription pipeline changes only. No changes to the core UI layout or navigation. Minor upload form additions for new configuration options.
+
+### Out of Scope
+
+- Switching away from WhisperX or Pyannote
+- Real-time transcription
+- Cloud deployment or GPU infrastructure
+- Performance optimization (speed)
+
+## User Stories
+
+### US-1: Audio Preprocessing
+
+As a user uploading a meeting recorded in a large room, I want the system to automatically clean up the audio before transcription so that distant speakers and background noise don't degrade accuracy.
+
+**Acceptance criteria:**
+- Audio undergoes preprocessing (high-pass filter, noise reduction, loudness normalization) before transcription
+- Preprocessing is enabled by default but can be disabled per upload
+- Preprocessing does not degrade quality for clean, close-mic recordings
+
+### US-2: Vocabulary Hints (Initial Prompt)
+
+As a user, I want to provide context about the meeting (attendee names, company names, technical terms) so that the transcriber recognizes these words correctly.
+
+**Acceptance criteria:**
+- Upload form includes an optional "Context / vocabulary hints" text area
+- Global default hints can be configured (e.g., company name, common terms)
+- Hints are passed to WhisperX as `initial_prompt`
+- UI indicates the ~150 word practical limit
+
+### US-3: Thai Language Alignment
+
+As a user transcribing Thai or mixed English/Thai meetings, I want the system to perform word-level alignment for Thai audio so that timestamps and speaker assignments are as accurate as for English.
+
+**Acceptance criteria:**
+- Thai (`th`) is added to supported alignment languages
+- Uses `airesearch/wav2vec2-large-xlsr-53-th` alignment model
+- Thai alignment model is downloaded on first use (same as other alignment models)
+
+### US-4: Improved Diarization Controls
+
+As a user, I want to provide a speaker count range (min/max) instead of an exact number so that the diarization algorithm has better constraints without requiring me to know the exact count.
+
+**Acceptance criteria:**
+- Upload form supports min speakers and max speakers fields (in addition to existing exact count)
+- When exact count is provided, min/max are ignored
+- When only min is provided, diarization preserves at least that many speakers
+- Default behavior (no hints) remains unchanged
+
+### US-5: Diarization Sensitivity Tuning
+
+As an administrator, I want to configure the diarization clustering threshold so that the system can be tuned to favor splitting over merging speakers.
+
+**Acceptance criteria:**
+- `DIARIZATION_THRESHOLD` env var controls clustering sensitivity
+- Default value preserves current behavior
+- Lower values reduce speaker merging (at the cost of potential over-splitting)
+- Requires replacing WhisperX's diarization wrapper with direct pyannote Pipeline usage
+
+## Business Rules
+
+| ID | Rule | Rationale |
+|----|------|-----------|
+| BR-1 | `initial_prompt` is truncated to 224 tokens (Whisper's internal limit). UI warns at ~150 words. | Whisper silently drops tokens beyond 224, which could mislead users. |
+| BR-2 | `min_speakers`/`max_speakers` are mutually exclusive with `num_speakers`. If exact count is set, range is ignored. | Pyannote does not accept both simultaneously. |
+| BR-3 | Audio preprocessing uses conservative noise reduction (`prop_decrease=0.75`). | Whisper was trained on noisy data. Aggressive noise removal can strip speech harmonics and hurt accuracy. |
+| BR-4 | Global vocabulary hints are prepended to per-meeting hints. Per-meeting hints take priority (placed last in prompt, where attention weight is highest). | Whisper's decoder assigns higher attention to tokens at the end of the initial prompt. |
+| BR-5 | Thai alignment model is loaded on-demand, not at startup. | Avoids downloading/loading models for languages not in use. Consistent with existing alignment model behavior. |
+
+## Data Requirements
+
+### Schema Changes (MeetingMetadata)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `initial_prompt` | `str \| None` | `None` | Vocabulary hints / context for Whisper decoder |
+| `min_speakers` | `int \| None` | `None` | Minimum expected speakers (diarization hint) |
+| `max_speakers` | `int \| None` | `None` | Maximum expected speakers (diarization hint) |
+| `preprocess_audio` | `bool` | `True` | Whether to apply audio preprocessing |
+
+### Configuration (env vars)
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `DIARIZATION_THRESHOLD` | `float` | `0.715` (pyannote default) | Clustering threshold. Lower = more speakers preserved. |
+| `DEFAULT_INITIAL_PROMPT` | `str` | `""` | Global default vocabulary hints prepended to per-meeting prompt. |
+
+### Dependencies (new)
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `noisereduce` | `>=3.0.0` | Spectral gating noise reduction |
+| `pyloudnorm` | `>=0.1.1` | ITU-R BS.1770 loudness normalization |
+
+## Edge Cases
+
+| Case | Expected Behavior |
+|------|-------------------|
+| `initial_prompt` exceeds 224 tokens | Whisper silently truncates from the start. UI shows a warning when input is long. |
+| Language auto-detect returns a language not in alignment list | Alignment is skipped gracefully (current behavior). Transcript uses segment-level timestamps. |
+| Mixed-language meeting (English/Thai) | Auto-detect picks dominant language. Alignment uses that language's model. Words in the secondary language may have less precise timestamps. |
+| `min_speakers` > actual speakers | Diarization may split one speaker into multiple. Acceptable tradeoff vs. merging. |
+| Audio is already clean (close-mic) | Preprocessing with conservative settings should not degrade quality. User can disable per upload if needed. |
+| `DIARIZATION_THRESHOLD` set too low | Over-splitting (one speaker appears as multiple). Documented in config with recommended range (0.4-0.8). |
+| Thai alignment model not yet downloaded | Downloaded automatically on first Thai transcription. May add ~1-2 min to first run. |
+
+## Open Questions
+
+| # | Question | Impact |
+|---|----------|--------|
+| 1 | Should preprocessing be applied before diarization only, before transcription only, or both? Using preprocessed audio for both is simpler but Whisper may handle raw audio better for transcription while diarization benefits more from clean audio. | Architecture: may need two audio paths |
+| 2 | For mixed English/Thai meetings, should users be able to specify "multilingual" as a language option to trigger alignment with multiple models? | Scope: significant complexity increase |
+| 3 | Should `DIARIZATION_THRESHOLD` be exposed per-meeting in the upload form, or kept as admin-only config? | UX: per-meeting adds complexity for non-technical users |
+| 4 | Is the `pyannote/speaker-diarization-community-1` model worth evaluating as an alternative to 3.1? It reportedly improves speaker counting but has different licensing. | Licensing and accuracy evaluation needed |
+
+## Implementation Notes
+
+**Suggested implementation order (incremental, each deliverable independently):**
+
+1. **Thai alignment** — Smallest change (~10 lines), immediate value for Thai meetings.
+2. **Vocabulary hints** — Schema + form field + 3 lines in transcriber. Quick win for proper noun accuracy.
+3. **Speaker count range** — Schema + form fields + pass-through to pyannote. Low effort.
+4. **Audio preprocessing** — New dependencies, new pipeline stage. Medium effort, high impact.
+5. **Diarization threshold tuning** — Requires replacing WhisperX wrapper with direct pyannote usage. Largest refactor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "argus-monorepo": "github:nimblehq/argus#feature/gh-67-python-stack"
+        "argus-monorepo": "github:nimblehq/argus#develop"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -353,7 +353,7 @@
       }
     },
     "node_modules/argus-monorepo": {
-      "resolved": "git+ssh://git@github.com/nimblehq/argus.git#09fb36b8057cf17d9100f27e23c2dfdd28599a66",
+      "resolved": "git+ssh://git@github.com/nimblehq/argus.git#2e7e71bbe7831f035713e69f712bef705918ae36",
       "dev": true,
       "workspaces": [
         "packages/core",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "argus-monorepo": "github:nimblehq/argus#feature/gh-67-python-stack"
+    "argus-monorepo": "github:nimblehq/argus#develop"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+per-file-ignores = { "transcriber.py" = ["E402"] }
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,13 @@ source = ["backend", "config"]
 [tool.coverage.report]
 show_missing = true
 fail_under = 80
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest>=8.0.0
 pytest-asyncio>=0.24.0
 httpx>=0.27.0
 pytest-cov>=6.0.0
+ruff>=0.9.0

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -68,9 +68,7 @@ class TestJobStageEnum:
 
 class TestTranscriptSegment:
     def test_creation(self):
-        seg = TranscriptSegment(
-            id="seg-1", start=0.0, end=5.5, speaker="SPEAKER_00", text="Hello"
-        )
+        seg = TranscriptSegment(id="seg-1", start=0.0, end=5.5, speaker="SPEAKER_00", text="Hello")
         assert seg.id == "seg-1"
         assert seg.start == 0.0
         assert seg.end == 5.5
@@ -78,9 +76,7 @@ class TestTranscriptSegment:
         assert seg.text == "Hello"
 
     def test_serialization(self):
-        seg = TranscriptSegment(
-            id="seg-1", start=1.0, end=2.0, speaker="SPEAKER_01", text="Hi"
-        )
+        seg = TranscriptSegment(id="seg-1", start=1.0, end=2.0, speaker="SPEAKER_01", text="Hi")
         data = seg.model_dump()
         assert data == {
             "id": "seg-1",
@@ -102,9 +98,7 @@ class TestTranscript:
         assert t.language == "en"
 
     def test_with_segments(self):
-        seg = TranscriptSegment(
-            id="s1", start=0.0, end=1.0, speaker="SP00", text="Test"
-        )
+        seg = TranscriptSegment(id="s1", start=0.0, end=1.0, speaker="SP00", text="Test")
         t = Transcript(segments=[seg], language="fr")
         assert len(t.segments) == 1
         assert t.language == "fr"

--- a/transcriber.py
+++ b/transcriber.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-import warnings
-import logging
 import os
 import sys
+import warnings
+
 from dotenv import load_dotenv
 
 # Suppress noisy warnings from dependencies (must be done before imports)
@@ -35,8 +35,9 @@ sys.stderr = _FilteredStream(sys.stderr)
 
 # Fix for PyTorch 2.6+ which changed weights_only default to True
 # pyannote/whisperx models aren't yet compatible with weights_only=True
-import torch
 import functools
+
+import torch
 
 _original_torch_load = torch.load
 
@@ -329,15 +330,15 @@ def format_transcript_txt(result: dict, speaker_names: dict = None) -> str:
     """Format transcript as readable text with timestamps and speaker labels."""
     lines = []
     speaker_names = speaker_names or {}
-    
+
     for segment in result["segments"]:
         timestamp = format_timestamp(segment["start"])
         speaker = segment.get("speaker", "UNKNOWN")
         speaker_display = speaker_names.get(speaker, speaker)
         text = segment["text"].strip()
-        
+
         lines.append(f"[{timestamp}] {speaker_display}: {text}")
-    
+
     return "\n".join(lines)
 
 
@@ -345,33 +346,33 @@ def format_transcript_srt(result: dict, speaker_names: dict = None) -> str:
     """Format transcript as SRT subtitles with speaker labels."""
     lines = []
     speaker_names = speaker_names or {}
-    
+
     for i, segment in enumerate(result["segments"], 1):
         start = format_srt_timestamp(segment["start"])
         end = format_srt_timestamp(segment["end"])
         speaker = segment.get("speaker", "UNKNOWN")
         speaker_display = speaker_names.get(speaker, speaker)
         text = segment["text"].strip()
-        
+
         lines.append(f"{i}")
         lines.append(f"{start} --> {end}")
         lines.append(f"[{speaker_display}] {text}")
         lines.append("")
-    
+
     return "\n".join(lines)
 
 
 def format_transcript_json(result: dict, speaker_names: dict = None) -> str:
     """Format transcript as JSON."""
     speaker_names = speaker_names or {}
-    
+
     output = {
         "segments": [
             {
                 "start": segment["start"],
                 "end": segment["end"],
                 "speaker": speaker_names.get(
-                    segment.get("speaker", "UNKNOWN"), 
+                    segment.get("speaker", "UNKNOWN"),
                     segment.get("speaker", "UNKNOWN")
                 ),
                 "text": segment["text"].strip()
@@ -379,7 +380,7 @@ def format_transcript_json(result: dict, speaker_names: dict = None) -> str:
             for segment in result["segments"]
         ]
     }
-    
+
     return json.dumps(output, indent=2, ensure_ascii=False)
 
 

--- a/transcriber.py
+++ b/transcriber.py
@@ -19,16 +19,21 @@ _SUPPRESSED_MESSAGES = [
     "Performing voice activity detection",
 ]
 
+
 class _FilteredStream:
     def __init__(self, original):
         self.original = original
+
     def write(self, msg):
         if not any(s in msg for s in _SUPPRESSED_MESSAGES):
             self.original.write(msg)
+
     def flush(self):
         self.original.flush()
+
     def __getattr__(self, name):
         return getattr(self.original, name)
+
 
 sys.stdout = _FilteredStream(sys.stdout)
 sys.stderr = _FilteredStream(sys.stderr)
@@ -41,11 +46,13 @@ import torch
 
 _original_torch_load = torch.load
 
+
 @functools.wraps(_original_torch_load)
 def _patched_torch_load(*args, **kwargs):
     # Force weights_only=False to support older model formats
-    kwargs['weights_only'] = False
+    kwargs["weights_only"] = False
     return _original_torch_load(*args, **kwargs)
+
 
 torch.load = _patched_torch_load
 
@@ -87,9 +94,35 @@ CACHE_VERSION = 1
 # Languages supported by WhisperX alignment (wav2vec2 models)
 # Thai and other languages not in this list will skip alignment
 ALIGNMENT_LANGUAGES = {
-    "en", "fr", "de", "es", "it", "ja", "zh", "nl", "uk", "pt",
-    "ar", "cs", "ru", "pl", "hu", "fi", "fa", "el", "tr", "da",
-    "he", "vi", "ko", "ur", "te", "hi", "ta", "id", "ms"
+    "en",
+    "fr",
+    "de",
+    "es",
+    "it",
+    "ja",
+    "zh",
+    "nl",
+    "uk",
+    "pt",
+    "ar",
+    "cs",
+    "ru",
+    "pl",
+    "hu",
+    "fi",
+    "fa",
+    "el",
+    "tr",
+    "da",
+    "he",
+    "vi",
+    "ko",
+    "ur",
+    "te",
+    "hi",
+    "ta",
+    "id",
+    "ms",
 }
 
 
@@ -174,6 +207,7 @@ def format_srt_timestamp(seconds: float) -> str:
 
 class TranscriptionError(Exception):
     """Raised when transcription fails."""
+
     pass
 
 
@@ -265,10 +299,7 @@ def transcribe_meeting(
     if detected_language in ALIGNMENT_LANGUAGES:
         log("Aligning timestamps...", quiet)
         try:
-            model_a, metadata = whisperx.load_align_model(
-                language_code=detected_language,
-                device=device
-            )
+            model_a, metadata = whisperx.load_align_model(language_code=detected_language, device=device)
             result = whisperx.align(
                 result["segments"],
                 model_a,
@@ -314,9 +345,7 @@ def transcribe_meeting(
             diarize_segments = diarize_model(audio, **diarize_kwargs)
             result = assign_word_speakers(diarize_segments, result)
 
-            unique_speakers = set(
-                s.get("speaker", "UNKNOWN") for s in result["segments"]
-            )
+            unique_speakers = set(s.get("speaker", "UNKNOWN") for s in result["segments"])
             log(f"Identified speakers: {len(unique_speakers)}", quiet)
         except Exception as e:
             raise TranscriptionError(f"Speaker diarization failed: {e}")
@@ -371,11 +400,8 @@ def format_transcript_json(result: dict, speaker_names: dict = None) -> str:
             {
                 "start": segment["start"],
                 "end": segment["end"],
-                "speaker": speaker_names.get(
-                    segment.get("speaker", "UNKNOWN"),
-                    segment.get("speaker", "UNKNOWN")
-                ),
-                "text": segment["text"].strip()
+                "speaker": speaker_names.get(segment.get("speaker", "UNKNOWN"), segment.get("speaker", "UNKNOWN")),
+                "text": segment["text"].strip(),
             }
             for segment in result["segments"]
         ]
@@ -395,7 +421,7 @@ def identify_speakers(result: dict) -> dict:
             text = segment["text"].strip()
             if len(text) > max_preview_len:
                 text = text[:max_preview_len] + "..."
-            speakers[speaker] = f"[{timestamp}] \"{text}\""
+            speakers[speaker] = f'[{timestamp}] "{text}"'
     return speakers
 
 
@@ -424,84 +450,38 @@ def prompt_speaker_names(result: dict) -> dict:
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Transcribe audio/video files with speaker diarization"
-    )
+    parser = argparse.ArgumentParser(description="Transcribe audio/video files with speaker diarization")
     parser.add_argument("audio_file", help="Path to audio/video file")
     parser.add_argument(
         "--model",
         default="large-v3",
         choices=["tiny", "base", "small", "medium", "large-v3"],
-        help="Whisper model size (default: large-v3)"
+        help="Whisper model size (default: large-v3)",
     )
+    parser.add_argument("--output", "-o", help="Output file path (default: same name as input with .txt extension)")
     parser.add_argument(
-        "--output", "-o",
-        help="Output file path (default: same name as input with .txt extension)"
+        "--format", "-f", default="txt", choices=["txt", "srt", "json"], help="Output format (default: txt)"
     )
-    parser.add_argument(
-        "--format", "-f",
-        default="txt",
-        choices=["txt", "srt", "json"],
-        help="Output format (default: txt)"
-    )
-    parser.add_argument(
-        "--device",
-        choices=["cuda", "cpu"],
-        help="Device to use (default: auto-detect)"
-    )
-    parser.add_argument(
-        "--batch-size",
-        type=int,
-        help="Batch size for transcription (default: 16 for CUDA, 4 for CPU)"
-    )
-    parser.add_argument(
-        "--language",
-        help="Language code (e.g., 'en', 'fr'). Auto-detected if not specified."
-    )
-    parser.add_argument(
-        "--speakers",
-        help="Comma-separated speaker names in order (e.g., 'Alice,Bob,Carol')"
-    )
-    parser.add_argument(
-        "--num-speakers",
-        type=int,
-        help="Exact number of speakers (helps diarization accuracy)"
-    )
-    parser.add_argument(
-        "--min-speakers",
-        type=int,
-        help="Minimum number of speakers"
-    )
-    parser.add_argument(
-        "--max-speakers",
-        type=int,
-        help="Maximum number of speakers"
-    )
+    parser.add_argument("--device", choices=["cuda", "cpu"], help="Device to use (default: auto-detect)")
+    parser.add_argument("--batch-size", type=int, help="Batch size for transcription (default: 16 for CUDA, 4 for CPU)")
+    parser.add_argument("--language", help="Language code (e.g., 'en', 'fr'). Auto-detected if not specified.")
+    parser.add_argument("--speakers", help="Comma-separated speaker names in order (e.g., 'Alice,Bob,Carol')")
+    parser.add_argument("--num-speakers", type=int, help="Exact number of speakers (helps diarization accuracy)")
+    parser.add_argument("--min-speakers", type=int, help="Minimum number of speakers")
+    parser.add_argument("--max-speakers", type=int, help="Maximum number of speakers")
     parser.add_argument(
         "--identify-speakers",
         action="store_true",
-        help="Show first utterance from each speaker and exit (for mapping names)"
+        help="Show first utterance from each speaker and exit (for mapping names)",
     )
     parser.add_argument(
-        "--interactive", "-i",
-        action="store_true",
-        help="Interactively prompt for speaker names after transcription"
+        "--interactive", "-i", action="store_true", help="Interactively prompt for speaker names after transcription"
     )
+    parser.add_argument("--no-diarization", action="store_true", help="Skip speaker diarization")
     parser.add_argument(
-        "--no-diarization",
-        action="store_true",
-        help="Skip speaker diarization"
+        "--quiet", "-q", action="store_true", help="Suppress progress messages (only show errors and final output path)"
     )
-    parser.add_argument(
-        "--quiet", "-q",
-        action="store_true",
-        help="Suppress progress messages (only show errors and final output path)"
-    )
-    parser.add_argument(
-        "--no-cache",
-        action="store_true",
-        help="Ignore cached transcription and re-transcribe"
-    )
+    parser.add_argument("--no-cache", action="store_true", help="Ignore cached transcription and re-transcribe")
 
     args = parser.parse_args()
 
@@ -565,10 +545,7 @@ def main():
 
     # Build speaker name mapping
     speaker_names = {}
-    unique_speakers = sorted(set(
-        s.get("speaker", "UNKNOWN")
-        for s in result["segments"]
-    ))
+    unique_speakers = sorted(set(s.get("speaker", "UNKNOWN") for s in result["segments"]))
 
     if args.interactive and hf_token:
         # Interactive mode: prompt for each speaker name
@@ -582,8 +559,7 @@ def main():
 
         # Warn about mismatch
         if len(names) != len(unique_speakers) and not args.quiet:
-            print(f"Warning: {len(names)} names provided but "
-                  f"{len(unique_speakers)} speakers detected.")
+            print(f"Warning: {len(names)} names provided but {len(unique_speakers)} speakers detected.")
             if len(names) < len(unique_speakers):
                 print("Some speakers will keep their default IDs.")
             else:


### PR DESCRIPTION
Closes: https://github.com/nimblehq/audio-transcriber/issues/23

## Summary

Add Ruff as the single linting and formatting tool for the project. Configures rules (E, F, I, W), line length (120), and double quote style in `pyproject.toml`. Fixes all existing violations across the codebase.

## Approach

Ruff replaces the need for separate flake8/isort/black tools (BR4). The E402 rule is ignored for `transcriber.py` because it intentionally imports torch/whisperx after runtime warning suppression and monkey-patching. All other violations were auto-fixed via `ruff check --fix` and `ruff format`.

## Verification

- `ruff check .` passes (0 errors)
- `ruff format --check .` passes (20 files formatted)
- All 39 existing tests pass
- Architect review: no Critical or Major issues