### PR TITLE
Cancel stuck transcription from the UI

### DIFF
--- a/backend/routers/meetings.py
+++ b/backend/routers/meetings.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 
 from backend.schemas import (
+    JobStatus,
     MeetingDetail,
     MeetingMetadata,
     MeetingStatus,
@@ -137,6 +138,25 @@ async def create_meeting(
     start_transcription(meeting_id, job.id)
 
     return {"meeting_id": meeting_id, "job_id": job.id}
+
+
+@router.post("/meetings/{meeting_id}/cancel")
+async def cancel_transcription(meeting_id: str):
+    metadata = _load_metadata(meeting_id)
+
+    if metadata.status != MeetingStatus.PROCESSING:
+        raise HTTPException(status_code=409, detail="Meeting is not currently processing")
+
+    error_message = "Transcription cancelled by user"
+
+    metadata.status = MeetingStatus.ERROR
+    metadata.error = error_message
+    _save_metadata(metadata)
+
+    if metadata.job_id:
+        job_queue.update_job(metadata.job_id, status=JobStatus.FAILED, error=error_message)
+
+    return {"ok": True}
 
 
 @router.post("/meetings/{meeting_id}/retry")

--- a/backend/routers/meetings.py
+++ b/backend/routers/meetings.py
@@ -165,6 +165,7 @@ async def retry_transcription(meeting_id: str):
 
     job = job_queue.create_job(meeting_id)
     metadata.status = MeetingStatus.PROCESSING
+    metadata.error = None
     metadata.job_id = job.id
     _save_metadata(metadata)
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -58,6 +58,7 @@ class MeetingMetadata(BaseModel):
     num_speakers: int | None = None
     job_id: str | None = None
     speakers: dict[str, str] = Field(default_factory=dict)
+    error: str | None = None
 
 
 class MeetingUpdate(BaseModel):

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -205,15 +205,17 @@ def _run_transcription(meeting_id: str, job_id: str):
         logger.exception("Transcription failed for meeting %s", meeting_id)
         job_queue.update_job(job_id, status=JobStatus.FAILED, error=str(e))
 
-        # Update meeting status to error
-        try:
-            with open(metadata_path) as f:
-                meta = json.load(f)
-            meta["status"] = "error"
-            with open(metadata_path, "w") as f:
-                json.dump(meta, f, ensure_ascii=False, indent=2)
-        except Exception:
-            pass
+        # Update meeting status to error (only if not already cancelled)
+        if not _is_cancelled(metadata_path):
+            try:
+                with open(metadata_path) as f:
+                    meta = json.load(f)
+                meta["status"] = "error"
+                meta["error"] = str(e)
+                with open(metadata_path, "w") as f:
+                    json.dump(meta, f, ensure_ascii=False, indent=2)
+            except Exception:
+                pass
 
 
 def start_transcription(meeting_id: str, job_id: str):

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import threading
+from pathlib import Path
 
 from backend.schemas import JobStatus, MeetingMetadata, MeetingStatus
 from backend.services.job_queue import job_queue
@@ -22,6 +23,16 @@ def _get_device() -> str:
     except ImportError:
         pass
     return "cpu"
+
+
+def _is_cancelled(metadata_path: Path) -> bool:
+    """Check if the meeting has been cancelled (status is no longer PROCESSING)."""
+    try:
+        with open(metadata_path) as f:
+            meta = json.load(f)
+        return meta.get("status") != MeetingStatus.PROCESSING.value
+    except Exception:
+        return False
 
 
 def _run_transcription(meeting_id: str, job_id: str):
@@ -165,6 +176,11 @@ def _run_transcription(meeting_id: str, job_id: str):
             "segments": segments,
             "language": detected_language,
         }
+
+        # Check if cancelled before saving results
+        if _is_cancelled(metadata_path):
+            logger.info("Transcription for meeting %s was cancelled, discarding results", meeting_id)
+            return
 
         # Save transcript
         transcript_path = meeting_dir / "transcript.json"

--- a/docs/plans/17-cancel-stuck-transcription.md
+++ b/docs/plans/17-cancel-stuck-transcription.md
@@ -1,0 +1,74 @@
+# Plan: Cancel stuck transcription from the UI
+
+**Story**: #17
+**Spec**: docs/specs/transcription-failure-recovery.md — F2
+**Branch**: feature/17-cancel-stuck-transcription
+**Date**: 2026-03-14
+**Mode**: TDD — pytest + httpx test client available with fixtures
+
+## Technical Decisions
+
+### TD-1: Add error field to MeetingMetadata
+- **Context**: Story requires storing "Transcription cancelled by user" message
+- **Decision**: Add `error: str | None = None` to MeetingMetadata
+- **Alternatives considered**: Storing error only in JobInfo (but metadata persists across restarts, jobs don't)
+
+### TD-2: Mark-and-ignore for thread cancellation
+- **Context**: Python threads can't be killed cleanly
+- **Decision**: Mark job as FAILED, let thread finish, check status before writing results
+- **Alternatives considered**: Using multiprocessing (overkill), threading.Event (requires plumbing through WhisperX calls)
+
+## Files to Create or Modify
+
+- `backend/schemas.py` — Add `error` field to MeetingMetadata
+- `backend/routers/meetings.py` — Add `POST /api/meetings/{id}/cancel` endpoint
+- `backend/services/transcriber.py` — Add `_is_cancelled()` check before saving results
+- `frontend/js/api.js` — Add `cancelTranscription()` method
+- `frontend/js/components/transcript-viewer.js` — Cancel button + error message display
+- `frontend/css/styles.css` — Cancel button styling
+- `tests/unit/test_transcriber.py` — Tests for `_is_cancelled()`
+- `tests/integration/test_cancel.py` — Integration tests for cancel endpoint
+- `tests/fixtures/metadata_error.json` — Add error field to fixture
+
+## Approach per AC
+
+### AC 1: New endpoint POST /api/meetings/{id}/cancel
+Load metadata, verify PROCESSING status (409 otherwise), set status=ERROR, error message, mark job FAILED.
+
+### AC 2: PROCESSING meetings show Cancel button
+Render cancel button in the processing state section of transcript-viewer.js.
+
+### AC 3: Confirmation dialog before cancelling
+Use `confirm()` before calling the cancel API.
+
+### AC 4: After cancelling, retry button appears
+Re-navigate to the meeting view which re-renders with ERROR state showing retry button.
+
+### AC 5: Error message set to "Transcription cancelled by user"
+Set in cancel endpoint, displayed in error state UI.
+
+### AC 6: API method added to api.js
+Add `cancelTranscription(id)` to the API object.
+
+### AC 7: Transcriber checks job status before writing results
+Add `_is_cancelled()` that reads metadata.json and checks if status is still PROCESSING.
+
+## Commit Sequence
+
+1. Add error field to MeetingMetadata schema + tests + fixture update
+2. Add cancel endpoint + integration tests
+3. Add cancellation check in transcriber + unit tests
+4. Add frontend cancel button, API method, error display
+
+## Risks and Trade-offs
+
+- Race condition between thread finishing and user cancelling is mitigated by the status check, but there's a small window where both could write metadata simultaneously. Acceptable for single-user app.
+- The cancelled thread continues consuming resources until it finishes naturally.
+
+## Deviations from Spec
+
+- Spec mentions "visible after 5 minutes, or always visible" — chose always visible for simplicity, since the user explicitly wants to cancel.
+
+## Deviations from Plan
+
+_None._

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -118,6 +118,19 @@ body {
     color: #e66;
 }
 
+.btn-cancel {
+    color: var(--danger);
+}
+
+.btn-cancel:hover {
+    color: #e66;
+}
+
+.cancel-section {
+    text-align: center;
+    margin-top: 0.5rem;
+}
+
 /* Page Header */
 .page-header {
     display: flex;

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -36,6 +36,12 @@ const API = {
         return res.json();
     },
 
+    async cancelTranscription(id) {
+        const res = await fetch(`/api/meetings/${id}/cancel`, { method: 'POST' });
+        if (!res.ok) throw new Error('Failed to cancel transcription');
+        return res.json();
+    },
+
     async retryTranscription(id) {
         const res = await fetch(`/api/meetings/${id}/retry`, { method: 'POST' });
         if (!res.ok) throw new Error('Failed to retry transcription');

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -29,8 +29,18 @@ async function loadMeetingView(container, meetingId) {
                     </div>
                 </div>
 
-                ${isProcessing ? `<div id="progress-section" class="progress-section"></div>` : ''}
-                ${isError ? `<div class="error-state">Transcription failed. <button class="btn btn-text" onclick="retryTranscription('${meetingId}')">Retry</button></div>` : ''}
+                ${isProcessing ? `
+                    <div id="progress-section" class="progress-section"></div>
+                    <div class="cancel-section">
+                        <button class="btn btn-text btn-cancel" onclick="handleCancelTranscription('${meetingId}')">Cancel transcription</button>
+                    </div>
+                ` : ''}
+                ${isError ? `
+                    <div class="error-state">
+                        ${meta.error ? escapeHtml(meta.error) : 'Transcription failed.'}
+                        <button class="btn btn-text" onclick="retryTranscription('${meetingId}')">Retry</button>
+                    </div>
+                ` : ''}
 
                 ${!isProcessing && !isError ? `
                     <div class="audio-player" id="audio-player">
@@ -353,6 +363,17 @@ async function retryTranscription(meetingId) {
         App.navigate(`/meetings/${meetingId}`);
     } catch (err) {
         showToast(err.message, 'error');
+    }
+}
+
+async function handleCancelTranscription(meetingId) {
+    if (!confirm('Are you sure? This will stop the current transcription.')) return;
+    try {
+        await API.cancelTranscription(meetingId);
+        showToast('Transcription cancelled');
+        App.navigate(`/meetings/${meetingId}`);
+    } catch (err) {
+        showToast('Failed to cancel transcription', 'error');
     }
 }
 

--- a/tests/fixtures/metadata_error.json
+++ b/tests/fixtures/metadata_error.json
@@ -9,5 +9,6 @@
   "language": "en",
   "num_speakers": null,
   "job_id": "job-003",
-  "speakers": {}
+  "speakers": {},
+  "error": "Transcription failed: Out of memory"
 }

--- a/tests/integration/test_cancel.py
+++ b/tests/integration/test_cancel.py
@@ -88,3 +88,4 @@ class TestCancelEndpoint:
         meeting_res = await client.get(f"/api/meetings/{processing_meeting}")
         meta = meeting_res.json()["metadata"]
         assert meta["status"] == "processing"
+        assert meta.get("error") is None

--- a/tests/integration/test_cancel.py
+++ b/tests/integration/test_cancel.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from backend.services.job_queue import job_queue
+
+
+@pytest.fixture
+def processing_meeting(meetings_dir: Path, sample_metadata_processing: dict, sample_audio: Path) -> str:
+    """Create a PROCESSING meeting on disk. Returns the meeting ID."""
+    meeting_id = sample_metadata_processing["id"]
+    meeting_dir = meetings_dir / meeting_id
+    meeting_dir.mkdir()
+
+    (meeting_dir / "metadata.json").write_text(json.dumps(sample_metadata_processing))
+    shutil.copy(sample_audio, meeting_dir / sample_metadata_processing["audio_filename"])
+
+    # Create a matching job in the queue
+    job = job_queue.create_job(meeting_id)
+    # Update fixture to use the real job ID
+    sample_metadata_processing["job_id"] = job.id
+    (meeting_dir / "metadata.json").write_text(json.dumps(sample_metadata_processing))
+
+    return meeting_id
+
+
+@pytest.fixture
+def ready_meeting(meetings_dir: Path, sample_metadata: dict, sample_audio: Path) -> str:
+    """Create a READY meeting on disk. Returns the meeting ID."""
+    meeting_id = sample_metadata["id"]
+    meeting_dir = meetings_dir / meeting_id
+    meeting_dir.mkdir()
+
+    (meeting_dir / "metadata.json").write_text(json.dumps(sample_metadata))
+    shutil.copy(sample_audio, meeting_dir / sample_metadata["audio_filename"])
+
+    return meeting_id
+
+
+class TestCancelEndpoint:
+    async def test_cancel_processing_meeting(self, client, processing_meeting):
+        res = await client.post(f"/api/meetings/{processing_meeting}/cancel")
+        assert res.status_code == 200
+
+        data = res.json()
+        assert data["ok"] is True
+
+        # Verify meeting status changed to error
+        meeting_res = await client.get(f"/api/meetings/{processing_meeting}")
+        meta = meeting_res.json()["metadata"]
+        assert meta["status"] == "error"
+        assert meta["error"] == "Transcription cancelled by user"
+
+    async def test_cancel_sets_job_to_failed(self, client, processing_meeting, meetings_dir):
+        # Get the job_id from metadata
+        meta_path = meetings_dir / processing_meeting / "metadata.json"
+        meta = json.loads(meta_path.read_text())
+        job_id = meta["job_id"]
+
+        await client.post(f"/api/meetings/{processing_meeting}/cancel")
+
+        job = job_queue.get_job(job_id)
+        assert job is not None
+        assert job.status.value == "failed"
+        assert job.error == "Transcription cancelled by user"
+
+    async def test_cancel_non_processing_meeting_returns_409(self, client, ready_meeting):
+        res = await client.post(f"/api/meetings/{ready_meeting}/cancel")
+        assert res.status_code == 409
+
+    async def test_cancel_nonexistent_meeting_returns_404(self, client):
+        res = await client.post("/api/meetings/nonexistent/cancel")
+        assert res.status_code == 404
+
+    async def test_retry_after_cancel(self, client, processing_meeting):
+        # Cancel first
+        await client.post(f"/api/meetings/{processing_meeting}/cancel")
+
+        # Verify retry works
+        res = await client.post(f"/api/meetings/{processing_meeting}/retry")
+        assert res.status_code == 200
+
+        # Verify status is back to processing
+        meeting_res = await client.get(f"/api/meetings/{processing_meeting}")
+        meta = meeting_res.json()["metadata"]
+        assert meta["status"] == "processing"

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -115,6 +115,7 @@ class TestMeetingMetadata:
         assert m.num_speakers is None
         assert m.job_id is None
         assert m.speakers == {}
+        assert m.error is None
         assert isinstance(m.created_at, datetime)
 
     def test_full_creation(self):
@@ -139,6 +140,10 @@ class TestMeetingMetadata:
         m2 = MeetingMetadata(**data)
         assert m2.id == m.id
         assert m2.title == m.title
+
+    def test_error_field(self):
+        m = MeetingMetadata(id="m1", title="Test", error="Transcription cancelled by user")
+        assert m.error == "Transcription cancelled by user"
 
     def test_from_fixture(self, sample_metadata: dict):
         m = MeetingMetadata(**sample_metadata)

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.schemas import MeetingMetadata, MeetingStatus
+from backend.services.transcriber import _is_cancelled
+
+
+class TestIsCancelled:
+    def test_returns_false_when_processing(self, tmp_path: Path):
+        meta = {"id": "m1", "title": "Test", "status": "processing", "audio_filename": "a.wav"}
+        meta_path = tmp_path / "metadata.json"
+        meta_path.write_text(json.dumps(meta))
+
+        assert _is_cancelled(meta_path) is False
+
+    def test_returns_true_when_error(self, tmp_path: Path):
+        meta = {"id": "m1", "title": "Test", "status": "error", "audio_filename": "a.wav"}
+        meta_path = tmp_path / "metadata.json"
+        meta_path.write_text(json.dumps(meta))
+
+        assert _is_cancelled(meta_path) is True
+
+    def test_returns_true_when_ready(self, tmp_path: Path):
+        meta = {"id": "m1", "title": "Test", "status": "ready", "audio_filename": "a.wav"}
+        meta_path = tmp_path / "metadata.json"
+        meta_path.write_text(json.dumps(meta))
+
+        assert _is_cancelled(meta_path) is True
+
+    def test_returns_false_on_read_error(self, tmp_path: Path):
+        meta_path = tmp_path / "nonexistent.json"
+        assert _is_cancelled(meta_path) is False

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
-from backend.schemas import MeetingMetadata, MeetingStatus
 from backend.services.transcriber import _is_cancelled
 
 


### PR DESCRIPTION
Closes #17

## Summary

Adds the ability to cancel a stuck transcription from the meeting detail view, setting the meeting to ERROR state so the existing retry mechanism can be used.

## Approach

The transcription thread can't be killed cleanly in Python, so the cancel endpoint marks the job as FAILED and the meeting as ERROR. A status check was added in `_run_transcription` before writing results — if the meeting is no longer PROCESSING (i.e. was cancelled), the thread discards its results silently.

Key changes:
- Add `error` field to `MeetingMetadata` schema for storing failure reasons
- Add `POST /api/meetings/{id}/cancel` endpoint (409 if not PROCESSING)
- Add `_is_cancelled()` check in transcriber before saving transcript
- Add cancel button with confirmation dialog in transcript-viewer.js
- Display error message in ERROR state UI
- Clear error field on retry

## Verification

- 49 tests pass (unit + integration)
- Ruff linting passes
- Integration tests cover: cancel flow, job state update, 409 for non-processing, 404 for missing, retry after cancel
- Unit tests cover: `_is_cancelled()` with all status variants and error cases