### PR TITLE
Add integration tests for all API endpoints

### DIFF
--- a/backend/services/job_queue.py
+++ b/backend/services/job_queue.py
@@ -32,6 +32,11 @@ class JobQueue:
         with self._lock:
             return self._jobs.get(job_id)
 
+    def clear(self):
+        """Remove all jobs. Used for test cleanup."""
+        with self._lock:
+            self._jobs.clear()
+
     def update_job(
         self,
         job_id: str,

--- a/docs/plans/21-integration-tests.md
+++ b/docs/plans/21-integration-tests.md
@@ -1,0 +1,81 @@
+# Plan: Integration Tests for API Endpoints
+
+**Story**: #21
+**Spec**: docs/specs/test-framework-setup.md (US3)
+**Branch**: feature/21-integration-tests
+**Date**: 2026-03-14
+**Mode**: Standard — testing existing code, TDD not applicable
+
+## Technical Decisions
+
+### TD-1: Mocking start_transcription
+- **Context**: POST /api/meetings and POST /api/meetings/{id}/retry spawn daemon threads via start_transcription
+- **Decision**: Patch `backend.routers.meetings.start_transcription` in upload/retry tests
+- **Alternatives considered**: Letting threads run — would cause side effects and test pollution
+
+### TD-2: Job queue singleton
+- **Context**: job_queue is a module-level singleton shared across tests
+- **Decision**: Use it directly for setup (creating jobs) and assertions; the in-memory nature makes this straightforward
+- **Alternatives considered**: Creating a fresh JobQueue per test — unnecessary complexity given test isolation via tmp_path
+
+### TD-3: Reusing existing conftest fixtures
+- **Context**: conftest.py already has client, data_dir, meetings_dir, populated_meeting, sample_audio fixtures
+- **Decision**: Reuse existing fixtures, add test-local fixtures only where needed (e.g., processing_meeting for retry tests)
+- **Alternatives considered**: Duplicating fixtures — violates DRY
+
+## Files to Create or Modify
+
+- `tests/integration/test_meetings.py` — Integration tests for all meetings router endpoints
+- `tests/integration/test_jobs.py` — Integration tests for jobs router endpoint
+- `tests/integration/test_analysis.py` — Integration tests for analysis/templates endpoint
+
+## Approach per AC
+
+### AC 1: GET /api/meetings
+List meetings, sort order by date desc, empty state returns []
+
+### AC 2: POST /api/meetings
+Upload with valid WAV, invalid extension rejected (400), mock start_transcription
+
+### AC 3: GET /api/meetings/{id}
+Existing meeting returns metadata+transcript, nonexistent returns 404
+
+### AC 4: PATCH /api/meetings/{id}
+Update title, type, speakers; verify persisted changes
+
+### AC 5: PATCH /api/meetings/{id}/segments/speaker
+Rename segment speaker, missing segment 404, missing transcript 404
+
+### AC 6: POST /api/meetings/{id}/retry
+Retry creates new job, updates status to processing; mock start_transcription
+
+### AC 7: DELETE /api/meetings/{id}
+Delete meeting, verify files removed; nonexistent returns 404
+
+### AC 8: GET /api/meetings/{id}/audio
+Stream audio file with correct media type; missing file returns 404
+
+### AC 9: GET /api/jobs/{jobId}
+Pending/completed/failed job states; nonexistent returns 404
+
+### AC 10: GET /api/templates/{type}
+Valid template types return content; invalid type returns 404
+
+## Commit Sequence
+
+1. Add integration tests for meetings endpoints
+2. Add integration tests for jobs endpoint
+3. Add integration tests for analysis/templates endpoint
+
+## Risks and Trade-offs
+
+- job_queue singleton state may leak between tests if not careful
+- start_transcription must always be mocked to avoid spawning real threads
+
+## Deviations from Spec
+
+- Cancel endpoint tests already exist in test_cancel.py (from issue #20), not duplicated here
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from backend.services.job_queue import job_queue
+
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
@@ -19,6 +21,13 @@ def _create_silence_wav(path: Path) -> None:
         f.setsampwidth(2)
         f.setframerate(16000)
         f.writeframes(struct.pack("<" + "h" * 16, *([0] * 16)))
+
+
+@pytest.fixture(autouse=True)
+def _clean_job_queue():
+    """Clear the job_queue singleton after each test to prevent state leakage."""
+    yield
+    job_queue.clear()
 
 
 @pytest.fixture

--- a/tests/integration/test_analysis.py
+++ b/tests/integration/test_analysis.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+class TestGetTemplate:
+    async def test_valid_template_types(self, client):
+        for template_type in ("interview", "sales", "client", "other"):
+            res = await client.get(f"/api/templates/{template_type}")
+            assert res.status_code == 200, f"Failed for type: {template_type}"
+            assert "template" in res.json()
+            assert len(res.json()["template"]) > 0
+
+    async def test_invalid_template_type(self, client):
+        res = await client.get("/api/templates/nonexistent")
+        assert res.status_code == 404

--- a/tests/integration/test_jobs.py
+++ b/tests/integration/test_jobs.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from backend.schemas import JobStatus
+from backend.services.job_queue import job_queue
+
+
+class TestGetJob:
+    async def test_pending_job(self, client):
+        job = job_queue.create_job("some-meeting")
+        res = await client.get(f"/api/jobs/{job.id}")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["status"] == "pending"
+        assert data["meeting_id"] == "some-meeting"
+
+    async def test_completed_job(self, client):
+        job = job_queue.create_job("some-meeting")
+        job_queue.update_job(job.id, status=JobStatus.COMPLETED, progress=100)
+        res = await client.get(f"/api/jobs/{job.id}")
+        assert res.status_code == 200
+        assert res.json()["status"] == "completed"
+        assert res.json()["progress"] == 100
+
+    async def test_failed_job(self, client):
+        job = job_queue.create_job("some-meeting")
+        job_queue.update_job(job.id, status=JobStatus.FAILED, error="Something broke")
+        res = await client.get(f"/api/jobs/{job.id}")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["status"] == "failed"
+        assert data["error"] == "Something broke"
+
+    async def test_nonexistent_job(self, client):
+        res = await client.get("/api/jobs/nonexistent")
+        assert res.status_code == 404

--- a/tests/integration/test_meetings.py
+++ b/tests/integration/test_meetings.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from backend.services.job_queue import job_queue
+
+
+@pytest.fixture
+def processing_meeting(meetings_dir: Path, sample_metadata_processing: dict, sample_audio: Path) -> str:
+    """Create a PROCESSING meeting on disk with a real job. Returns the meeting ID."""
+    meeting_id = sample_metadata_processing["id"]
+    meeting_dir = meetings_dir / meeting_id
+    meeting_dir.mkdir()
+
+    job = job_queue.create_job(meeting_id)
+    sample_metadata_processing["job_id"] = job.id
+    (meeting_dir / "metadata.json").write_text(json.dumps(sample_metadata_processing))
+    shutil.copy(sample_audio, meeting_dir / sample_metadata_processing["audio_filename"])
+
+    return meeting_id
+
+
+@pytest.fixture
+def error_meeting(meetings_dir: Path, sample_metadata_error: dict, sample_audio: Path) -> str:
+    """Create an ERROR meeting on disk. Returns the meeting ID."""
+    meeting_id = sample_metadata_error["id"]
+    meeting_dir = meetings_dir / meeting_id
+    meeting_dir.mkdir()
+
+    (meeting_dir / "metadata.json").write_text(json.dumps(sample_metadata_error))
+    shutil.copy(sample_audio, meeting_dir / sample_metadata_error["audio_filename"])
+
+    return meeting_id
+
+
+class TestListMeetings:
+    async def test_empty_state(self, client):
+        res = await client.get("/api/meetings")
+        assert res.status_code == 200
+        assert res.json() == []
+
+    async def test_returns_meetings(self, client, populated_meeting):
+        res = await client.get("/api/meetings")
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data) == 1
+        assert data[0]["id"] == populated_meeting
+        assert data[0]["title"] == "Weekly Standup"
+
+    async def test_sort_order_newest_first(self, client, meetings_dir: Path, sample_audio: Path):
+        """Multiple meetings are returned sorted by created_at descending."""
+        for i, date in enumerate(["2026-01-10T10:00:00", "2026-01-20T10:00:00", "2026-01-15T10:00:00"]):
+            mid = f"meeting-{i}"
+            d = meetings_dir / mid
+            d.mkdir()
+            meta = {
+                "id": mid,
+                "title": f"Meeting {i}",
+                "type": "other",
+                "created_at": date,
+                "audio_filename": "sample.wav",
+                "status": "ready",
+                "speakers": {},
+            }
+            (d / "metadata.json").write_text(json.dumps(meta))
+
+        res = await client.get("/api/meetings")
+        data = res.json()
+        assert len(data) == 3
+        assert data[0]["id"] == "meeting-1"  # Jan 20
+        assert data[1]["id"] == "meeting-2"  # Jan 15
+        assert data[2]["id"] == "meeting-0"  # Jan 10
+
+
+class TestCreateMeeting:
+    @patch("backend.routers.meetings.start_transcription")
+    async def test_upload_valid_file(self, mock_start, client, sample_audio: Path):
+        with open(sample_audio, "rb") as f:
+            res = await client.post(
+                "/api/meetings",
+                files={"file": ("test.wav", f, "audio/wav")},
+                data={"title": "Test Meeting", "meeting_type": "interview"},
+            )
+        assert res.status_code == 200
+        data = res.json()
+        assert "meeting_id" in data
+        assert "job_id" in data
+        mock_start.assert_called_once()
+
+    @patch("backend.routers.meetings.start_transcription")
+    async def test_upload_uses_filename_as_default_title(self, mock_start, client, sample_audio: Path):
+        with open(sample_audio, "rb") as f:
+            res = await client.post(
+                "/api/meetings",
+                files={"file": ("my-recording.wav", f, "audio/wav")},
+                data={"title": "", "meeting_type": "other"},
+            )
+        assert res.status_code == 200
+        meeting_id = res.json()["meeting_id"]
+
+        detail = await client.get(f"/api/meetings/{meeting_id}")
+        assert detail.json()["metadata"]["title"] == "my-recording"
+
+    async def test_upload_invalid_extension(self, client, tmp_path: Path):
+        fake = tmp_path / "test.txt"
+        fake.write_text("not audio")
+        with open(fake, "rb") as f:
+            res = await client.post(
+                "/api/meetings",
+                files={"file": ("test.txt", f, "text/plain")},
+                data={"title": "Bad File"},
+            )
+        assert res.status_code == 400
+        assert "Unsupported file format" in res.json()["detail"]
+
+    @patch("backend.routers.meetings.start_transcription")
+    async def test_upload_creates_files_on_disk(self, mock_start, client, sample_audio: Path, meetings_dir: Path):
+        with open(sample_audio, "rb") as f:
+            res = await client.post(
+                "/api/meetings",
+                files={"file": ("test.wav", f, "audio/wav")},
+                data={"title": "Disk Test"},
+            )
+        meeting_id = res.json()["meeting_id"]
+        meeting_dir = meetings_dir / meeting_id
+        assert meeting_dir.exists()
+        assert (meeting_dir / "metadata.json").exists()
+        assert (meeting_dir / "audio.wav").exists()
+
+
+class TestGetMeeting:
+    async def test_existing_meeting(self, client, populated_meeting):
+        res = await client.get(f"/api/meetings/{populated_meeting}")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["metadata"]["id"] == populated_meeting
+        assert data["transcript"] is not None
+        assert len(data["transcript"]["segments"]) == 4
+
+    async def test_nonexistent_meeting(self, client):
+        res = await client.get("/api/meetings/nonexistent")
+        assert res.status_code == 404
+
+
+class TestUpdateMeeting:
+    async def test_update_title(self, client, populated_meeting):
+        res = await client.patch(
+            f"/api/meetings/{populated_meeting}",
+            json={"title": "Updated Title"},
+        )
+        assert res.status_code == 200
+        assert res.json()["title"] == "Updated Title"
+
+    async def test_update_type(self, client, populated_meeting):
+        res = await client.patch(
+            f"/api/meetings/{populated_meeting}",
+            json={"type": "sales"},
+        )
+        assert res.status_code == 200
+        assert res.json()["type"] == "sales"
+
+    async def test_update_speakers(self, client, populated_meeting):
+        speakers = {"SPEAKER_00": "Charlie", "SPEAKER_01": "Dana"}
+        res = await client.patch(
+            f"/api/meetings/{populated_meeting}",
+            json={"speakers": speakers},
+        )
+        assert res.status_code == 200
+        assert res.json()["speakers"] == speakers
+
+    async def test_update_nonexistent_meeting(self, client):
+        res = await client.patch("/api/meetings/nonexistent", json={"title": "X"})
+        assert res.status_code == 404
+
+
+class TestUpdateSegmentSpeaker:
+    async def test_rename_segment_speaker(self, client, populated_meeting):
+        res = await client.patch(
+            f"/api/meetings/{populated_meeting}/segments/speaker",
+            json={"segment_id": "seg-001", "speaker_name": "Charlie"},
+        )
+        assert res.status_code == 200
+        assert res.json()["ok"] is True
+
+        # Verify the speaker mapping was saved
+        detail = await client.get(f"/api/meetings/{populated_meeting}")
+        speakers = detail.json()["metadata"]["speakers"]
+        assert "Charlie" in speakers.values()
+
+    async def test_missing_segment(self, client, populated_meeting):
+        res = await client.patch(
+            f"/api/meetings/{populated_meeting}/segments/speaker",
+            json={"segment_id": "nonexistent", "speaker_name": "X"},
+        )
+        assert res.status_code == 404
+        assert "Segment not found" in res.json()["detail"]
+
+    async def test_missing_transcript(self, client, meetings_dir: Path):
+        """Meeting exists but has no transcript.json."""
+        mid = "no-transcript"
+        d = meetings_dir / mid
+        d.mkdir()
+        meta = {
+            "id": mid,
+            "title": "No Transcript",
+            "type": "other",
+            "audio_filename": "audio.wav",
+            "status": "processing",
+            "speakers": {},
+        }
+        (d / "metadata.json").write_text(json.dumps(meta))
+
+        res = await client.patch(
+            f"/api/meetings/{mid}/segments/speaker",
+            json={"segment_id": "seg-001", "speaker_name": "X"},
+        )
+        assert res.status_code == 404
+        assert "Transcript not found" in res.json()["detail"]
+
+
+class TestRetryTranscription:
+    @patch("backend.routers.meetings.start_transcription")
+    async def test_retry_creates_new_job(self, mock_start, client, error_meeting):
+        res = await client.post(f"/api/meetings/{error_meeting}/retry")
+        assert res.status_code == 200
+        data = res.json()
+        assert "job_id" in data
+        mock_start.assert_called_once()
+
+        # Verify status changed to processing
+        detail = await client.get(f"/api/meetings/{error_meeting}")
+        assert detail.json()["metadata"]["status"] == "processing"
+
+    async def test_retry_nonexistent_meeting(self, client):
+        res = await client.post("/api/meetings/nonexistent/retry")
+        assert res.status_code == 404
+
+
+class TestDeleteMeeting:
+    async def test_delete_meeting(self, client, populated_meeting, meetings_dir: Path):
+        res = await client.delete(f"/api/meetings/{populated_meeting}")
+        assert res.status_code == 200
+        assert res.json()["ok"] is True
+        assert not (meetings_dir / populated_meeting).exists()
+
+    async def test_delete_nonexistent_meeting(self, client):
+        res = await client.delete("/api/meetings/nonexistent")
+        assert res.status_code == 404
+
+
+class TestStreamAudio:
+    async def test_stream_audio(self, client, populated_meeting):
+        res = await client.get(f"/api/meetings/{populated_meeting}/audio")
+        assert res.status_code == 200
+        assert res.headers["content-type"] == "audio/wav"
+
+    async def test_audio_missing_file(self, client, populated_meeting, meetings_dir: Path):
+        """Metadata exists but audio file was deleted."""
+        audio = meetings_dir / populated_meeting / "sample.wav"
+        audio.unlink()
+
+        res = await client.get(f"/api/meetings/{populated_meeting}/audio")
+        assert res.status_code == 404
+
+    async def test_audio_nonexistent_meeting(self, client):
+        res = await client.get("/api/meetings/nonexistent/audio")
+        assert res.status_code == 404


### PR DESCRIPTION
Closes: https://github.com/nimblehq/audio-transcriber/issues/21

## Summary

- Add integration tests covering all API endpoints: meetings CRUD, upload, audio streaming, retry, delete, jobs status queries, and analysis template retrieval
- Add job_queue cleanup fixture to prevent singleton state leakage between tests
- Add `clear()` method to `JobQueue` for test cleanup

## Approach

Used the existing async test client and conftest fixtures. Mocked `start_transcription` in upload/retry tests to avoid spawning real threads. Tests verify request/response contracts, error cases (404s, 400s), file system side effects, and sort ordering.

Cancel endpoint tests were already covered by #20, so they are not duplicated here.

## Verification

All 78 tests pass locally (`pytest --tb=short -q`). Ruff linting passes. Tests cover:
- `GET /api/meetings` — empty state, populated list, sort order
- `POST /api/meetings` — valid upload, invalid extension, file creation on disk, default title from filename
- `GET /api/meetings/{id}` — existing with transcript, 404
- `PATCH /api/meetings/{id}` — update title, type, speakers, 404
- `PATCH /api/meetings/{id}/segments/speaker` — rename speaker, missing segment 404, missing transcript 404
- `POST /api/meetings/{id}/retry` — creates new job, 404
- `DELETE /api/meetings/{id}` — deletes files, 404
- `GET /api/meetings/{id}/audio` — streams with correct content-type, missing file 404
- `GET /api/jobs/{jobId}` — pending, completed, failed states, 404
- `GET /api/templates/{type}` — valid types return content, invalid 404