### PR TITLE
#20 Add unit tests for services (job_queue, transcriber)

### DIFF
--- a/docs/plans/20-unit-tests-services.md
+++ b/docs/plans/20-unit-tests-services.md
@@ -1,0 +1,64 @@
+# Plan: Unit Tests for Services
+
+**Story**: #20
+**Spec**: docs/specs/test-framework-setup.md (US2)
+**Branch**: feature/20-unit-tests-services
+**Date**: 2026-03-14
+**Mode**: Standard — testing existing code, not writing new production code
+
+## Technical Decisions
+
+### TD-1: Mock strategy for _run_transcription
+- **Context**: The function lazily imports whisperx, torch, and pyannote inside its body
+- **Decision**: Use `unittest.mock.patch` to mock these at their import paths within the function scope, plus mock config module values
+- **Alternatives considered**: Installing ML deps in test — too heavy, non-deterministic
+
+### TD-2: Thread safety test for JobQueue
+- **Context**: JobQueue uses threading.Lock for concurrency safety
+- **Decision**: Use concurrent.futures.ThreadPoolExecutor to verify no exceptions under concurrent access
+- **Alternatives considered**: Single-threaded tests only — would not exercise the locking logic
+
+## Files to Create or Modify
+
+- `tests/unit/test_job_queue.py` — new, unit tests for JobQueue class
+- `tests/unit/test_transcriber.py` — extend with tests for `_get_device`, `_run_transcription`, `start_transcription`
+
+## Approach per AC
+
+### AC 1: Unit tests for job_queue.py
+- create_job returns JobInfo with correct fields and PENDING status
+- get_job returns None for unknown ID
+- update_job modifies only specified fields and updates timestamp
+- update_job silently ignores missing job
+- clear removes all jobs
+- Thread safety under concurrent create/update operations
+
+### AC 2: Unit tests for transcriber.py
+- `_get_device` returns config value when not "auto", detects cuda/cpu when "auto"
+- `_run_transcription` happy path: mocked pipeline writes transcript.json, updates metadata to READY
+- `_run_transcription` error: sets job to FAILED, writes error to metadata
+- `_run_transcription` cancellation: discards results when cancelled mid-run
+- `start_transcription` spawns a daemon thread
+
+### AC 3: All tests pass
+- Verify with `pytest tests/unit/` from project root
+
+## Commit Sequence
+
+1. Add plan for #20
+2. Add unit tests for job_queue.py
+3. Add unit tests for transcriber.py (_get_device)
+4. Add unit tests for transcriber.py (_run_transcription and start_transcription)
+
+## Risks and Trade-offs
+
+- `_run_transcription` has heavy coupling to module-level config imports — requires careful patching
+- Lazy imports inside function body need patching at the right level (builtins.__import__ or sys.modules)
+
+## Deviations from Spec
+
+- Spec US2 includes config.py and schemas.py tests; those are covered by issue #19
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/tests/unit/test_job_queue.py
+++ b/tests/unit/test_job_queue.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from backend.schemas import JobStatus
+from backend.services.job_queue import JobQueue
+
+
+class TestCreateJob:
+    def test_returns_job_info_with_pending_status(self):
+        queue = JobQueue()
+        job = queue.create_job("meeting-1")
+
+        assert job.meeting_id == "meeting-1"
+        assert job.status == JobStatus.PENDING
+        assert job.progress == 0
+        assert job.stage == ""
+        assert job.error is None
+
+    def test_assigns_unique_ids(self):
+        queue = JobQueue()
+        job1 = queue.create_job("m1")
+        job2 = queue.create_job("m2")
+
+        assert job1.id != job2.id
+
+    def test_sets_created_and_updated_timestamps(self):
+        queue = JobQueue()
+        job = queue.create_job("m1")
+
+        assert job.created_at is not None
+        assert job.updated_at is not None
+        assert job.created_at == job.updated_at
+
+
+class TestGetJob:
+    def test_returns_created_job(self):
+        queue = JobQueue()
+        created = queue.create_job("m1")
+        fetched = queue.get_job(created.id)
+
+        assert fetched is not None
+        assert fetched.id == created.id
+        assert fetched.meeting_id == "m1"
+
+    def test_returns_none_for_unknown_id(self):
+        queue = JobQueue()
+        assert queue.get_job("nonexistent") is None
+
+
+class TestUpdateJob:
+    def test_updates_status(self):
+        queue = JobQueue()
+        job = queue.create_job("m1")
+        queue.update_job(job.id, status=JobStatus.PROCESSING)
+
+        assert queue.get_job(job.id).status == JobStatus.PROCESSING
+
+    def test_updates_progress_and_stage(self):
+        queue = JobQueue()
+        job = queue.create_job("m1")
+        queue.update_job(job.id, progress=50, stage="transcribing")
+
+        updated = queue.get_job(job.id)
+        assert updated.progress == 50
+        assert updated.stage == "transcribing"
+
+    def test_updates_error(self):
+        queue = JobQueue()
+        job = queue.create_job("m1")
+        queue.update_job(job.id, error="something broke")
+
+        assert queue.get_job(job.id).error == "something broke"
+
+    def test_only_updates_specified_fields(self):
+        queue = JobQueue()
+        job = queue.create_job("m1")
+        queue.update_job(job.id, status=JobStatus.PROCESSING)
+        queue.update_job(job.id, progress=50)
+
+        updated = queue.get_job(job.id)
+        assert updated.status == JobStatus.PROCESSING
+        assert updated.progress == 50
+
+    def test_updates_timestamp(self):
+        queue = JobQueue()
+        job = queue.create_job("m1")
+        original_updated_at = job.updated_at
+        queue.update_job(job.id, progress=10)
+
+        assert queue.get_job(job.id).updated_at >= original_updated_at
+
+    def test_silently_ignores_missing_job(self):
+        queue = JobQueue()
+        queue.update_job("nonexistent", status=JobStatus.FAILED)  # no exception
+
+
+class TestClear:
+    def test_removes_all_jobs(self):
+        queue = JobQueue()
+        job1 = queue.create_job("m1")
+        job2 = queue.create_job("m2")
+        queue.clear()
+
+        assert queue.get_job(job1.id) is None
+        assert queue.get_job(job2.id) is None
+
+
+class TestThreadSafety:
+    def test_concurrent_create_and_update(self):
+        queue = JobQueue()
+        num_jobs = 50
+
+        def create_and_update(i: int) -> str:
+            job = queue.create_job(f"meeting-{i}")
+            queue.update_job(job.id, status=JobStatus.PROCESSING, progress=i)
+            return job.id
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(create_and_update, i) for i in range(num_jobs)]
+            job_ids = [f.result() for f in as_completed(futures)]
+
+        assert len(set(job_ids)) == num_jobs
+
+        for job_id in job_ids:
+            job = queue.get_job(job_id)
+            assert job is not None
+            assert job.status == JobStatus.PROCESSING

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -1,9 +1,53 @@
 from __future__ import annotations
 
 import json
+import struct
+import threading
+import wave
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from backend.services.transcriber import _is_cancelled
+from backend.schemas import JobStatus, MeetingStatus
+from backend.services.job_queue import JobQueue
+from backend.services.transcriber import _get_device, _is_cancelled
+
+
+def _create_test_audio(path: Path) -> None:
+    """Create a minimal valid WAV file for testing."""
+    with wave.open(str(path), "wb") as f:
+        f.setnchannels(1)
+        f.setsampwidth(2)
+        f.setframerate(16000)
+        f.writeframes(struct.pack("<" + "h" * 16, *([0] * 16)))
+
+
+def _create_meeting_on_disk(
+    meetings_dir: Path,
+    meeting_id: str = "test-meeting",
+    status: str = "processing",
+    audio_filename: str = "audio.wav",
+    language: str = "auto",
+    num_speakers: int | None = None,
+) -> Path:
+    """Create a meeting directory with metadata and audio file."""
+    meeting_dir = meetings_dir / meeting_id
+    meeting_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata = {
+        "id": meeting_id,
+        "title": "Test Meeting",
+        "type": "other",
+        "status": status,
+        "audio_filename": audio_filename,
+        "language": language,
+        "num_speakers": num_speakers,
+        "created_at": "2026-03-14T00:00:00",
+        "speakers": {},
+    }
+    (meeting_dir / "metadata.json").write_text(json.dumps(metadata))
+    _create_test_audio(meeting_dir / audio_filename)
+
+    return meeting_dir
 
 
 class TestIsCancelled:
@@ -31,3 +75,285 @@ class TestIsCancelled:
     def test_returns_false_on_read_error(self, tmp_path: Path):
         meta_path = tmp_path / "nonexistent.json"
         assert _is_cancelled(meta_path) is False
+
+
+class TestGetDevice:
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "cuda")
+    def test_returns_configured_device(self):
+        assert _get_device() == "cuda"
+
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
+    def test_returns_cpu_when_configured(self):
+        assert _get_device() == "cpu"
+
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "auto")
+    def test_auto_falls_back_to_cpu_without_torch(self):
+        with patch.dict("sys.modules", {"torch": None}):
+            assert _get_device() == "cpu"
+
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "auto")
+    def test_auto_detects_cuda(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            assert _get_device() == "cuda"
+
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "auto")
+    def test_auto_returns_cpu_when_no_cuda(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            assert _get_device() == "cpu"
+
+
+class TestRunTranscription:
+    """Tests for _run_transcription with all ML dependencies mocked."""
+
+    def _build_mocks(self):
+        """Create mock objects for whisperx and torch."""
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_audio.return_value = MagicMock()
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {
+            "segments": [
+                {"start": 0.0, "end": 1.5, "text": " Hello there.", "speaker": "SPEAKER_00"},
+                {"start": 1.5, "end": 3.0, "text": " How are you?", "speaker": "SPEAKER_01"},
+            ],
+            "language": "en",
+        }
+        mock_whisperx.load_model.return_value = mock_model
+        mock_whisperx.load_align_model.return_value = (MagicMock(), MagicMock())
+        mock_whisperx.align.return_value = {
+            "segments": [
+                {"start": 0.0, "end": 1.5, "text": " Hello there.", "speaker": "SPEAKER_00"},
+                {"start": 1.5, "end": 3.0, "text": " How are you?", "speaker": "SPEAKER_01"},
+            ],
+        }
+
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+
+        mock_diarize_pipeline = MagicMock()
+        mock_assign_speakers = MagicMock(return_value={
+            "segments": [
+                {"start": 0.0, "end": 1.5, "text": " Hello there.", "speaker": "SPEAKER_00"},
+                {"start": 1.5, "end": 3.0, "text": " How are you?", "speaker": "SPEAKER_01"},
+            ],
+        })
+
+        return mock_whisperx, mock_torch, mock_diarize_pipeline, mock_assign_speakers
+
+    @patch("backend.services.transcriber.WHISPER_BATCH_SIZE", 16)
+    @patch("backend.services.transcriber.WHISPER_MODEL", "large-v3")
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
+    @patch("backend.services.transcriber.HF_TOKEN", "test-token")
+    def test_happy_path_writes_transcript_and_updates_metadata(self, tmp_path: Path):
+        mock_whisperx, mock_torch, mock_diarize_cls, mock_assign = self._build_mocks()
+        queue = JobQueue()
+        meetings_dir = tmp_path / "meetings"
+        meeting_dir = _create_meeting_on_disk(meetings_dir)
+        job = queue.create_job("test-meeting")
+
+        with (
+            patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
+            patch("backend.services.transcriber.job_queue", queue),
+            patch.dict("sys.modules", {
+                "whisperx": mock_whisperx,
+                "torch": mock_torch,
+                "whisperx.diarize": MagicMock(
+                    DiarizationPipeline=mock_diarize_cls,
+                    assign_word_speakers=mock_assign,
+                ),
+                "functools": __import__("functools"),
+                "warnings": __import__("warnings"),
+            }),
+        ):
+            from backend.services.transcriber import _run_transcription
+
+            _run_transcription("test-meeting", job.id)
+
+        # Verify transcript written
+        transcript_path = meeting_dir / "transcript.json"
+        assert transcript_path.exists()
+        transcript = json.loads(transcript_path.read_text())
+        assert len(transcript["segments"]) == 2
+        assert transcript["segments"][0]["text"] == "Hello there."
+        assert transcript["segments"][0]["speaker"] == "SPEAKER_00"
+        assert transcript["language"] == "en"
+
+        # Verify metadata updated to READY
+        metadata = json.loads((meeting_dir / "metadata.json").read_text())
+        assert metadata["status"] == MeetingStatus.READY.value
+        assert metadata["duration_seconds"] == 3.0
+        assert "SPEAKER_00" in metadata["speakers"]
+        assert "SPEAKER_01" in metadata["speakers"]
+
+        # Verify job completed
+        updated_job = queue.get_job(job.id)
+        assert updated_job.status == JobStatus.COMPLETED
+        assert updated_job.progress == 100
+
+    @patch("backend.services.transcriber.WHISPER_BATCH_SIZE", 16)
+    @patch("backend.services.transcriber.WHISPER_MODEL", "large-v3")
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
+    @patch("backend.services.transcriber.HF_TOKEN", "")
+    def test_skips_diarization_without_hf_token(self, tmp_path: Path):
+        mock_whisperx, mock_torch, mock_diarize_cls, mock_assign = self._build_mocks()
+        queue = JobQueue()
+        meetings_dir = tmp_path / "meetings"
+        _create_meeting_on_disk(meetings_dir)
+        job = queue.create_job("test-meeting")
+
+        with (
+            patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
+            patch("backend.services.transcriber.job_queue", queue),
+            patch.dict("sys.modules", {
+                "whisperx": mock_whisperx,
+                "torch": mock_torch,
+                "whisperx.diarize": MagicMock(
+                    DiarizationPipeline=mock_diarize_cls,
+                    assign_word_speakers=mock_assign,
+                ),
+                "functools": __import__("functools"),
+                "warnings": __import__("warnings"),
+            }),
+        ):
+            from backend.services.transcriber import _run_transcription
+
+            _run_transcription("test-meeting", job.id)
+
+        # Diarization pipeline should not be called
+        mock_diarize_cls.assert_not_called()
+
+    @patch("backend.services.transcriber.WHISPER_BATCH_SIZE", 16)
+    @patch("backend.services.transcriber.WHISPER_MODEL", "large-v3")
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
+    @patch("backend.services.transcriber.HF_TOKEN", "")
+    def test_error_sets_job_failed_and_updates_metadata(self, tmp_path: Path):
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_audio.side_effect = RuntimeError("Audio file corrupt")
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+
+        queue = JobQueue()
+        meetings_dir = tmp_path / "meetings"
+        meeting_dir = _create_meeting_on_disk(meetings_dir)
+        job = queue.create_job("test-meeting")
+
+        with (
+            patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
+            patch("backend.services.transcriber.job_queue", queue),
+            patch.dict("sys.modules", {
+                "whisperx": mock_whisperx,
+                "torch": mock_torch,
+                "whisperx.diarize": MagicMock(),
+                "functools": __import__("functools"),
+                "warnings": __import__("warnings"),
+            }),
+        ):
+            from backend.services.transcriber import _run_transcription
+
+            _run_transcription("test-meeting", job.id)
+
+        # Job should be FAILED
+        updated_job = queue.get_job(job.id)
+        assert updated_job.status == JobStatus.FAILED
+        assert "Audio file corrupt" in updated_job.error
+
+        # Metadata should have error status
+        metadata = json.loads((meeting_dir / "metadata.json").read_text())
+        assert metadata["status"] == "error"
+        assert "Audio file corrupt" in metadata["error"]
+
+    @patch("backend.services.transcriber.WHISPER_BATCH_SIZE", 16)
+    @patch("backend.services.transcriber.WHISPER_MODEL", "large-v3")
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
+    @patch("backend.services.transcriber.HF_TOKEN", "")
+    def test_discards_results_when_cancelled(self, tmp_path: Path):
+        mock_whisperx, mock_torch, mock_diarize_cls, mock_assign = self._build_mocks()
+        queue = JobQueue()
+        meetings_dir = tmp_path / "meetings"
+        meeting_dir = _create_meeting_on_disk(meetings_dir)
+        job = queue.create_job("test-meeting")
+
+        # Change status to "error" before saving results to simulate cancellation
+        def cancel_before_save(*args, **kwargs):
+            meta = json.loads((meeting_dir / "metadata.json").read_text())
+            meta["status"] = "error"
+            (meeting_dir / "metadata.json").write_text(json.dumps(meta))
+            return mock_whisperx.align.return_value
+
+        # Make align trigger the cancellation
+        mock_whisperx.align.side_effect = cancel_before_save
+
+        with (
+            patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
+            patch("backend.services.transcriber.job_queue", queue),
+            patch.dict("sys.modules", {
+                "whisperx": mock_whisperx,
+                "torch": mock_torch,
+                "whisperx.diarize": MagicMock(
+                    DiarizationPipeline=mock_diarize_cls,
+                    assign_word_speakers=mock_assign,
+                ),
+                "functools": __import__("functools"),
+                "warnings": __import__("warnings"),
+            }),
+        ):
+            from backend.services.transcriber import _run_transcription
+
+            _run_transcription("test-meeting", job.id)
+
+        # Transcript should NOT be written
+        assert not (meeting_dir / "transcript.json").exists()
+
+    @patch("backend.services.transcriber.WHISPER_BATCH_SIZE", 16)
+    @patch("backend.services.transcriber.WHISPER_MODEL", "large-v3")
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
+    @patch("backend.services.transcriber.HF_TOKEN", "")
+    def test_no_speech_detected_raises_error(self, tmp_path: Path):
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_audio.return_value = MagicMock()
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"segments": [], "language": "en"}
+        mock_whisperx.load_model.return_value = mock_model
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+
+        queue = JobQueue()
+        meetings_dir = tmp_path / "meetings"
+        _create_meeting_on_disk(meetings_dir)
+        job = queue.create_job("test-meeting")
+
+        with (
+            patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
+            patch("backend.services.transcriber.job_queue", queue),
+            patch.dict("sys.modules", {
+                "whisperx": mock_whisperx,
+                "torch": mock_torch,
+                "whisperx.diarize": MagicMock(),
+                "functools": __import__("functools"),
+                "warnings": __import__("warnings"),
+            }),
+        ):
+            from backend.services.transcriber import _run_transcription
+
+            _run_transcription("test-meeting", job.id)
+
+        updated_job = queue.get_job(job.id)
+        assert updated_job.status == JobStatus.FAILED
+        assert "No speech detected" in updated_job.error
+
+
+class TestStartTranscription:
+    def test_spawns_daemon_thread(self):
+        with patch("backend.services.transcriber._run_transcription") as mock_run:
+            from backend.services.transcriber import start_transcription
+
+            start_transcription("m1", "j1")
+
+            # Give the thread a moment to start
+            import time
+            time.sleep(0.05)
+
+            mock_run.assert_called_once_with("m1", "j1")

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import struct
-import threading
 import wave
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -134,12 +133,14 @@ class TestRunTranscription:
         mock_torch.cuda.is_available.return_value = False
 
         mock_diarize_pipeline = MagicMock()
-        mock_assign_speakers = MagicMock(return_value={
-            "segments": [
-                {"start": 0.0, "end": 1.5, "text": " Hello there.", "speaker": "SPEAKER_00"},
-                {"start": 1.5, "end": 3.0, "text": " How are you?", "speaker": "SPEAKER_01"},
-            ],
-        })
+        mock_assign_speakers = MagicMock(
+            return_value={
+                "segments": [
+                    {"start": 0.0, "end": 1.5, "text": " Hello there.", "speaker": "SPEAKER_00"},
+                    {"start": 1.5, "end": 3.0, "text": " How are you?", "speaker": "SPEAKER_01"},
+                ],
+            }
+        )
 
         return mock_whisperx, mock_torch, mock_diarize_pipeline, mock_assign_speakers
 
@@ -157,16 +158,19 @@ class TestRunTranscription:
         with (
             patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
             patch("backend.services.transcriber.job_queue", queue),
-            patch.dict("sys.modules", {
-                "whisperx": mock_whisperx,
-                "torch": mock_torch,
-                "whisperx.diarize": MagicMock(
-                    DiarizationPipeline=mock_diarize_cls,
-                    assign_word_speakers=mock_assign,
-                ),
-                "functools": __import__("functools"),
-                "warnings": __import__("warnings"),
-            }),
+            patch.dict(
+                "sys.modules",
+                {
+                    "whisperx": mock_whisperx,
+                    "torch": mock_torch,
+                    "whisperx.diarize": MagicMock(
+                        DiarizationPipeline=mock_diarize_cls,
+                        assign_word_speakers=mock_assign,
+                    ),
+                    "functools": __import__("functools"),
+                    "warnings": __import__("warnings"),
+                },
+            ),
         ):
             from backend.services.transcriber import _run_transcription
 
@@ -207,16 +211,19 @@ class TestRunTranscription:
         with (
             patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
             patch("backend.services.transcriber.job_queue", queue),
-            patch.dict("sys.modules", {
-                "whisperx": mock_whisperx,
-                "torch": mock_torch,
-                "whisperx.diarize": MagicMock(
-                    DiarizationPipeline=mock_diarize_cls,
-                    assign_word_speakers=mock_assign,
-                ),
-                "functools": __import__("functools"),
-                "warnings": __import__("warnings"),
-            }),
+            patch.dict(
+                "sys.modules",
+                {
+                    "whisperx": mock_whisperx,
+                    "torch": mock_torch,
+                    "whisperx.diarize": MagicMock(
+                        DiarizationPipeline=mock_diarize_cls,
+                        assign_word_speakers=mock_assign,
+                    ),
+                    "functools": __import__("functools"),
+                    "warnings": __import__("warnings"),
+                },
+            ),
         ):
             from backend.services.transcriber import _run_transcription
 
@@ -243,13 +250,16 @@ class TestRunTranscription:
         with (
             patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
             patch("backend.services.transcriber.job_queue", queue),
-            patch.dict("sys.modules", {
-                "whisperx": mock_whisperx,
-                "torch": mock_torch,
-                "whisperx.diarize": MagicMock(),
-                "functools": __import__("functools"),
-                "warnings": __import__("warnings"),
-            }),
+            patch.dict(
+                "sys.modules",
+                {
+                    "whisperx": mock_whisperx,
+                    "torch": mock_torch,
+                    "whisperx.diarize": MagicMock(),
+                    "functools": __import__("functools"),
+                    "warnings": __import__("warnings"),
+                },
+            ),
         ):
             from backend.services.transcriber import _run_transcription
 
@@ -289,16 +299,19 @@ class TestRunTranscription:
         with (
             patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
             patch("backend.services.transcriber.job_queue", queue),
-            patch.dict("sys.modules", {
-                "whisperx": mock_whisperx,
-                "torch": mock_torch,
-                "whisperx.diarize": MagicMock(
-                    DiarizationPipeline=mock_diarize_cls,
-                    assign_word_speakers=mock_assign,
-                ),
-                "functools": __import__("functools"),
-                "warnings": __import__("warnings"),
-            }),
+            patch.dict(
+                "sys.modules",
+                {
+                    "whisperx": mock_whisperx,
+                    "torch": mock_torch,
+                    "whisperx.diarize": MagicMock(
+                        DiarizationPipeline=mock_diarize_cls,
+                        assign_word_speakers=mock_assign,
+                    ),
+                    "functools": __import__("functools"),
+                    "warnings": __import__("warnings"),
+                },
+            ),
         ):
             from backend.services.transcriber import _run_transcription
 
@@ -328,13 +341,16 @@ class TestRunTranscription:
         with (
             patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
             patch("backend.services.transcriber.job_queue", queue),
-            patch.dict("sys.modules", {
-                "whisperx": mock_whisperx,
-                "torch": mock_torch,
-                "whisperx.diarize": MagicMock(),
-                "functools": __import__("functools"),
-                "warnings": __import__("warnings"),
-            }),
+            patch.dict(
+                "sys.modules",
+                {
+                    "whisperx": mock_whisperx,
+                    "torch": mock_torch,
+                    "whisperx.diarize": MagicMock(),
+                    "functools": __import__("functools"),
+                    "warnings": __import__("warnings"),
+                },
+            ),
         ):
             from backend.services.transcriber import _run_transcription
 
@@ -354,6 +370,7 @@ class TestStartTranscription:
 
             # Give the thread a moment to start
             import time
+
             time.sleep(0.05)
 
             mock_run.assert_called_once_with("m1", "j1")


### PR DESCRIPTION
Closes: https://github.com/nimblehq/audio-transcriber/issues/20

## Summary

Add comprehensive unit tests for the two backend services — `job_queue.py` and `transcriber.py` — with all ML dependencies (WhisperX, PyAnnote, torch) fully mocked.

- 13 tests for `JobQueue`: create, get, update, clear, thread safety
- 15 tests for `transcriber`: `_is_cancelled`, `_get_device`, `_run_transcription` (happy path, error handling, cancellation, no speech), `start_transcription`

## Approach

Mock strategy uses `patch.dict("sys.modules", ...)` for the lazily-imported ML dependencies inside `_run_transcription`, and standard `@patch` decorators for config values. Each test creates isolated file system state via `tmp_path` and a fresh `JobQueue` instance (not the singleton) to avoid test pollution.

Thread safety is verified by hammering `JobQueue` with 50 concurrent create+update operations via `ThreadPoolExecutor`.

## Verification

- All 102 tests pass (`pytest -v`)
- Architect review passed — fixed unused import and formatting