### PR TITLE
Recover stuck PROCESSING meetings on app startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -5,8 +7,16 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from backend.routers import analysis, jobs, meetings
+from backend.services.recovery import recover_stuck_meetings
 
-app = FastAPI(title="Meeting Transcriber")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    recover_stuck_meetings()
+    yield
+
+
+app = FastAPI(title="Meeting Transcriber", lifespan=lifespan)
 
 app.include_router(meetings.router, prefix="/api")
 app.include_router(jobs.router, prefix="/api")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path

--- a/backend/services/recovery.py
+++ b/backend/services/recovery.py
@@ -24,11 +24,16 @@ def recover_stuck_meetings() -> list[str]:
         if metadata.get("status") != "processing":
             continue
 
-        metadata["status"] = "error"
-        metadata["error"] = "Transcription interrupted by app restart"
-        metadata_path.write_text(json.dumps(metadata, indent=2))
-
         meeting_id = metadata.get("id", metadata_path.parent.name)
+
+        try:
+            metadata["status"] = "error"
+            metadata["error"] = "Transcription interrupted by app restart"
+            metadata_path.write_text(json.dumps(metadata, indent=2))
+        except OSError:
+            logger.exception("Failed to update metadata for meeting: %s", meeting_id)
+            continue
+
         recovered.append(meeting_id)
         logger.info("Recovered stuck meeting: %s", meeting_id)
 

--- a/backend/services/recovery.py
+++ b/backend/services/recovery.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from config import MEETINGS_DIR
+
+logger = logging.getLogger(__name__)
+
+
+def recover_stuck_meetings() -> list[str]:
+    """Scan all meetings and transition any with status=PROCESSING to ERROR.
+
+    Returns a list of recovered meeting IDs.
+    """
+    recovered: list[str] = []
+
+    for metadata_path in MEETINGS_DIR.glob("*/metadata.json"):
+        try:
+            metadata = json.loads(metadata_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if metadata.get("status") != "processing":
+            continue
+
+        metadata["status"] = "error"
+        metadata["error"] = "Transcription interrupted by app restart"
+        metadata_path.write_text(json.dumps(metadata, indent=2))
+
+        meeting_id = metadata.get("id", metadata_path.parent.name)
+        recovered.append(meeting_id)
+        logger.info("Recovered stuck meeting: %s", meeting_id)
+
+    if recovered:
+        logger.info("Recovered %d stuck meeting(s)", len(recovered))
+
+    return recovered

--- a/docs/plans/16-recover-stuck-processing-meetings.md
+++ b/docs/plans/16-recover-stuck-processing-meetings.md
@@ -1,0 +1,56 @@
+# Plan: Recover stuck PROCESSING meetings on startup
+
+**Story**: #16
+**Spec**: docs/specs/transcription-failure-recovery.md (F1)
+**Branch**: feature/16-recover-stuck-processing-meetings
+**Date**: 2026-03-14
+**Mode**: Standard — simple file I/O logic, straightforward to test after implementation
+
+## Technical Decisions
+
+### TD-1: Separate recovery service module
+- **Context**: Recovery logic needs to scan disk and update metadata files
+- **Decision**: Create `backend/services/recovery.py` to keep `main.py` clean
+- **Alternatives considered**: Inline in `main.py` lifespan — rejected for testability
+
+### TD-2: FastAPI lifespan context manager
+- **Context**: Need to run recovery on startup before serving requests
+- **Decision**: Use `@asynccontextmanager` lifespan pattern (modern FastAPI)
+- **Alternatives considered**: `@app.on_event("startup")` — deprecated in recent FastAPI
+
+## Files to Create or Modify
+
+- `backend/services/recovery.py` — **New**: `recover_stuck_meetings()` function
+- `backend/main.py` — Add lifespan context manager wiring recovery on startup
+- `tests/unit/test_recovery.py` — **New**: Unit tests for recovery
+
+## Approach per AC
+
+### AC 1: Scan all meeting directories for metadata with status=PROCESSING
+Glob `MEETINGS_DIR/*/metadata.json`, load each, check `status` field.
+
+### AC 2: Set status to ERROR with error message
+Update matching metadata dicts: `status=error`, `error="Transcription interrupted by app restart"`, write back.
+
+### AC 3: Log each recovered meeting ID
+Use `logger.info()` per recovered meeting.
+
+### AC 4: Recovered meetings show retry button in the UI
+No UI changes needed — ERROR status already shows the retry button.
+
+## Commit Sequence
+
+1. Add `recover_stuck_meetings` service + unit tests
+2. Wire recovery into FastAPI lifespan in `main.py`
+
+## Risks and Trade-offs
+
+- No race condition risk — threads don't survive process restart
+
+## Deviations from Spec
+
+- None anticipated
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/tests/unit/test_recovery.py
+++ b/tests/unit/test_recovery.py
@@ -36,9 +36,7 @@ class TestRecoverStuckMeetings:
         assert sorted(recovered) == ["m1", "m2"]
 
         for mid in ["m1", "m2"]:
-            metadata = json.loads(
-                (meetings_dir / mid / "metadata.json").read_text()
-            )
+            metadata = json.loads((meetings_dir / mid / "metadata.json").read_text())
             assert metadata["status"] == "error"
             assert metadata["error"] == "Transcription interrupted by app restart"
 
@@ -52,9 +50,7 @@ class TestRecoverStuckMeetings:
         assert recovered == []
 
         # Verify they were not modified
-        ready_meta = json.loads(
-            (meetings_dir / "ready1" / "metadata.json").read_text()
-        )
+        ready_meta = json.loads((meetings_dir / "ready1" / "metadata.json").read_text())
         assert ready_meta["status"] == "ready"
 
     def test_mixed_statuses(self, meetings_dir):

--- a/tests/unit/test_recovery.py
+++ b/tests/unit/test_recovery.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from backend.services.recovery import recover_stuck_meetings
+
+
+@pytest.fixture
+def meetings_dir(tmp_path):
+    d = tmp_path / "meetings"
+    d.mkdir()
+    return d
+
+
+def _create_meeting(meetings_dir, meeting_id, status, error=None):
+    meeting_dir = meetings_dir / meeting_id
+    meeting_dir.mkdir()
+    metadata = {"id": meeting_id, "status": status}
+    if error is not None:
+        metadata["error"] = error
+    (meeting_dir / "metadata.json").write_text(json.dumps(metadata))
+    return meeting_dir
+
+
+class TestRecoverStuckMeetings:
+    def test_recovers_processing_meetings(self, meetings_dir):
+        _create_meeting(meetings_dir, "m1", "processing")
+        _create_meeting(meetings_dir, "m2", "processing")
+
+        with patch("backend.services.recovery.MEETINGS_DIR", meetings_dir):
+            recovered = recover_stuck_meetings()
+
+        assert sorted(recovered) == ["m1", "m2"]
+
+        for mid in ["m1", "m2"]:
+            metadata = json.loads(
+                (meetings_dir / mid / "metadata.json").read_text()
+            )
+            assert metadata["status"] == "error"
+            assert metadata["error"] == "Transcription interrupted by app restart"
+
+    def test_ignores_non_processing_meetings(self, meetings_dir):
+        _create_meeting(meetings_dir, "ready1", "ready")
+        _create_meeting(meetings_dir, "error1", "error", error="some error")
+
+        with patch("backend.services.recovery.MEETINGS_DIR", meetings_dir):
+            recovered = recover_stuck_meetings()
+
+        assert recovered == []
+
+        # Verify they were not modified
+        ready_meta = json.loads(
+            (meetings_dir / "ready1" / "metadata.json").read_text()
+        )
+        assert ready_meta["status"] == "ready"
+
+    def test_mixed_statuses(self, meetings_dir):
+        _create_meeting(meetings_dir, "proc1", "processing")
+        _create_meeting(meetings_dir, "ready1", "ready")
+        _create_meeting(meetings_dir, "err1", "error")
+
+        with patch("backend.services.recovery.MEETINGS_DIR", meetings_dir):
+            recovered = recover_stuck_meetings()
+
+        assert recovered == ["proc1"]
+
+    def test_empty_meetings_dir(self, meetings_dir):
+        with patch("backend.services.recovery.MEETINGS_DIR", meetings_dir):
+            recovered = recover_stuck_meetings()
+
+        assert recovered == []
+
+    def test_skips_malformed_metadata(self, meetings_dir):
+        bad_dir = meetings_dir / "bad"
+        bad_dir.mkdir()
+        (bad_dir / "metadata.json").write_text("not json")
+
+        _create_meeting(meetings_dir, "good", "processing")
+
+        with patch("backend.services.recovery.MEETINGS_DIR", meetings_dir):
+            recovered = recover_stuck_meetings()
+
+        assert recovered == ["good"]
+
+    def test_logs_recovered_meetings(self, meetings_dir, caplog):
+        _create_meeting(meetings_dir, "m1", "processing")
+
+        with patch("backend.services.recovery.MEETINGS_DIR", meetings_dir):
+            import logging
+
+            with caplog.at_level(logging.INFO):
+                recover_stuck_meetings()
+
+        assert "Recovered stuck meeting: m1" in caplog.text
+        assert "Recovered 1 stuck meeting(s)" in caplog.text

--- a/tests/unit/test_recovery.py
+++ b/tests/unit/test_recovery.py
@@ -65,7 +65,7 @@ class TestRecoverStuckMeetings:
         with patch("backend.services.recovery.MEETINGS_DIR", meetings_dir):
             recovered = recover_stuck_meetings()
 
-        assert recovered == ["proc1"]
+        assert sorted(recovered) == ["proc1"]
 
     def test_empty_meetings_dir(self, meetings_dir):
         with patch("backend.services.recovery.MEETINGS_DIR", meetings_dir):


### PR DESCRIPTION
Closes: https://github.com/nimblehq/audio-transcriber/issues/16

## Summary

On app restart, meetings left in PROCESSING status become orphaned since job state is in-memory only. This adds a startup recovery mechanism that scans all meetings and transitions any stuck PROCESSING meetings to ERROR status, enabling users to retry them via the existing retry button.

## Approach

Added a `recover_stuck_meetings()` function in a new `backend/services/recovery.py` module, wired into FastAPI's lifespan context manager so it runs before the app starts serving requests. Each stuck meeting is individually recovered with error handling so one failure doesn't abort the rest.

No UI changes needed — ERROR status meetings already display the retry button.

## Verification

- 6 unit tests covering: recovery of processing meetings, ignoring non-processing meetings, mixed statuses, empty directory, malformed metadata, and logging output
- Full test suite passes (112 tests)
- Manual verification: created a meeting with status=processing in data dir, started the app, confirmed it was set to error with the correct message