### PR TITLE
Refine meeting analysis templates

### DIFF
--- a/docs/plans/meeting-analysis-templates-refinement.md
+++ b/docs/plans/meeting-analysis-templates-refinement.md
@@ -1,0 +1,81 @@
+# Plan: Meeting Analysis Templates Refinement
+
+**Story**: docs/specs/meeting-analysis-templates-refinement.md
+**Spec**: docs/specs/meeting-analysis-templates-refinement.md
+**Branch**: feature/meeting-analysis-templates-refinement
+**Date**: 2026-04-02
+**Mode**: Standard — Template content changes only; no testable code behaviors
+
+## Technical Decisions
+
+### TD-1: Replace templates in-place
+- **Context**: Spec's open question about versioning during transition
+- **Decision**: Replace templates in-place without versioning
+- **Alternatives considered**: Adding v2 suffix to filenames; decided against per spec instruction "Template content changes only"
+
+### TD-2: Include explicit word count guidance
+- **Context**: Spec's concern about LLMs not reliably hitting length targets
+- **Decision**: Include explicit word count targets in prompt instructions
+- **Alternatives considered**: Relying solely on structural guidance; adding both for better compliance
+
+### TD-3: Include confidence levels for interpretive observations
+- **Context**: Spec's question about confidence calibration for nuanced interpretations
+- **Decision**: Instruct LLM to rate confidence for "Intent vs. words" and "Potential Issues" observations
+- **Alternatives considered**: Omitting confidence ratings; decided to include per spec edge case guidance
+
+## Files to Create or Modify
+
+- `templates/sales_meeting_analysis.md` — Complete rewrite with dual-output, tiered sections, effectiveness assessment, signal detection, and self-assessment
+- `templates/client_meeting_analysis.md` — Complete rewrite with dual-output, tiered sections, effectiveness assessment, signal detection, and self-assessment
+- `templates/other.md` — Complete rewrite with tiered sections, effectiveness assessment, signal detection, and self-assessment
+
+## Approach per Goal
+
+### Goal 1: Reduce template verbosity by 40-50%
+- Remove redundant table structures
+- Use bullets over tables where appropriate
+- Combine similar sections
+- Focus on actionable insights over exhaustive categorization
+
+### Goal 2: Introduce tiered sections
+- Mark each section as Required or Content-Dependent in template metadata
+- Add explicit LLM instructions to omit content-dependent sections when insufficient signal
+
+### Goal 3: Add client-shareable output (client template)
+- Add dual-output structure: Internal Analysis + Client-Shareable Summary
+- Include clear separation with content safety guidelines
+- Never include sentiment, private observations, risks, potential issues in shareable output
+
+### Goal 4: Add meeting effectiveness assessment
+- Add four-dimension assessment framework (decision yield, data readiness, circular discussion, intent vs. words)
+- Include behavioral change meta-principle
+- Internal-facing only
+
+### Goal 5: Create sales follow-up format (sales template)
+- Add dual-output structure: Sales Intelligence + Prospect Follow-Up
+- Include professional thank-you email format
+
+### Goal 6: Enable personal performance tracking
+- Add opt-in prompt at template start
+- Include metrics, observations, patterns to watch
+- Include Trackable Summary line format for longitudinal tracking
+
+## Commit Sequence
+
+1. `Refine sales meeting analysis template` — Add dual-output, tiered sections, effectiveness assessment, contribution analysis, signal detection, self-assessment, potential issues
+2. `Refine client meeting analysis template` — Add dual-output, tiered sections, effectiveness assessment, contribution analysis, signal detection, self-assessment, potential issues
+3. `Refine general meeting analysis template` — Add tiered sections, effectiveness assessment, contribution analysis, signal detection, self-assessment, potential issues
+
+## Risks and Trade-offs
+
+- **LLM compliance**: Templates are instructions, not code; LLM behavior may vary. Mitigated by clear, explicit instructions.
+- **Length targets**: LLMs may not hit exact word counts. Mitigated by structural guidance + explicit word count notes.
+- **Breaking user expectations**: Users familiar with old format will see new output structure. This is an intentional improvement per the spec.
+
+## Deviations from Spec
+
+_None planned._
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/docs/plans/meeting-analysis-templates-refinement.md
+++ b/docs/plans/meeting-analysis-templates-refinement.md
@@ -78,4 +78,5 @@ _None planned._
 
 ## Deviations from Plan
 
-_Populated after implementation._
+- Added explicit handling for "transcript-only limitations" edge case (spec requirement, discovered during QA)
+- Added explicit handling for "self-assessment speaker not found" edge case (spec requirement, discovered during QA)

--- a/docs/specs/meeting-analysis-templates-refinement.md
+++ b/docs/specs/meeting-analysis-templates-refinement.md
@@ -1,0 +1,533 @@
+# Meeting Analysis Templates Refinement
+
+## Overview
+
+### Problem Statement
+
+The current meeting analysis templates are too long and rigid, leading to repetitive output and burying essential insights in verbose structure. Users need concise, actionable meeting intelligence without sacrificing valuable insights. Additionally, there's no template suitable for sharing directly with clients after meetings.
+
+### Goals
+
+1. **Reduce template verbosity** by 40-50% while preserving essential insights
+2. **Introduce tiered sections** (required vs. content-dependent) to reduce rigidity
+3. **Add a client-shareable output** to the client meeting template for professional post-meeting summaries
+4. **Add meeting effectiveness assessment** to internal templates based on behavioral change principles
+5. **Create a follow-up format** for sales meetings to support prospect communication
+6. **Enable personal performance tracking** through optional self-assessment in analysis output
+
+### Scope
+
+**In scope:**
+- Sales meeting analysis template
+- Client meeting analysis template
+- General/other meeting template
+- New client-shareable summary output (dual-output from client template)
+- New sales follow-up output (dual-output from sales template)
+
+**Out of scope:**
+- Interview analysis template (migrating to another system)
+- Prototype scope template (no changes requested)
+
+## User Stories
+
+### Template Refinement
+- As a Nimble team member, I want meeting analysis output that's half the current length so I can quickly extract key insights without wading through repetitive sections.
+- As a Nimble team member, I want templates that only include relevant sections based on what was actually discussed so the output feels tailored rather than boilerplate.
+
+### Client-Shareable Summary
+- As a Nimble consultant, I want to generate a professional meeting summary I can email directly to clients after every project meeting so they have a clear record of decisions and next steps.
+- As a Nimble consultant, I want both internal notes and a client-shareable summary from a single template run so I don't have to process the transcript twice.
+
+### Sales Follow-Up
+- As a Nimble sales team member, I want a polished follow-up email format generated alongside my sales analysis so I can quickly send a professional thank-you with key points.
+
+### Meeting Effectiveness
+- As a Nimble team member, I want to understand whether a meeting actually changed what people will do next, not just what they discussed, so I can identify meetings that waste time vs. drive progress.
+
+### Advanced Signal Detection
+- As a Nimble team member, I want the analysis to surface non-obvious signals (hedging patterns, question quality, convergence speed) so I can catch issues that surface-level summaries miss.
+- As a Nimble team member, I want to know when commitments are vague or lack accountability so I can clarify before the meeting ends or follow up immediately.
+
+### Personal Performance Tracking
+- As a Nimble team member, I want to see an analysis of my own contribution when I participated in a meeting so I can track my effectiveness over time.
+- As a Nimble team member, I want a consistent, compact format for my self-assessment so I can easily compare my performance across meetings.
+
+## Business Rules
+
+### Scope of Analysis: Single-Meeting Observations
+
+**Important clarification:** This spec covers per-meeting analysis — what happened in THIS meeting and what should be done next. The analysis surfaces signals and observations from individual meetings, not diagnoses or assessments that require longitudinal data.
+
+Some signals (e.g., psychological safety indicators, participation patterns) become meaningful only when tracked across multiple meetings. A single observation is a data point, not a conclusion:
+- One person being quiet in one meeting ≠ psychological safety problem (they may be new, tired, or lack relevant input)
+- One rapid convergence ≠ groupthink (the answer may have been obvious)
+- One dominant speaker ≠ problematic pattern (they may have been the subject matter expert)
+
+Templates should frame observations appropriately:
+- Use "In this meeting..." not "This team has..."
+- Use "may indicate" not "shows"
+- Note when patterns would need confirmation across meetings
+
+Team performance analytics (tracking patterns across meetings) is a separate capability outside this app's scope.
+
+### Tiered Section System
+
+Templates must use a two-tier section system:
+
+| Tier | Behavior | Rationale |
+|------|----------|-----------|
+| **Required** | Always included in output | Core information that's always valuable |
+| **Content-dependent** | Include only if transcript contains relevant discussion | Reduces noise and repetition |
+
+The LLM decides which content-dependent sections to include based on transcript analysis. Users do not need to provide upfront context.
+
+### Dual-Output Structure
+
+**Client Meeting Template:**
+```
+## Internal Analysis
+[Full notes with effectiveness assessment, sentiment, private observations]
+
+## Client-Shareable Summary
+[Polished, concise: Summary → Decisions → Action Items → Next Steps]
+```
+
+**Sales Meeting Template:**
+```
+## Sales Intelligence
+[Full analysis with deal signals, competitive info, strategy]
+
+## Prospect Follow-Up
+[Thank-you format with key discussion points and next steps]
+```
+
+### Output Length Guidelines
+
+| Template | Target Length | Notes |
+|----------|---------------|-------|
+| Sales - Intelligence | ~400-500 words | Focus on actionable insights |
+| Sales - Follow-up | ~150-200 words | Brief, professional email format |
+| Client - Internal | ~400-500 words | Comprehensive but scannable |
+| Client - Shareable | ~200-300 words | Executive summary style |
+| Other/General | ~300-400 words | Flexible based on meeting complexity |
+
+### Meeting Effectiveness Assessment
+
+Include in internal-facing outputs only. Assess meetings against four principles, anchored by one meta-principle:
+
+**Meta-principle:** A meeting is effective when it changes what people will do next — not just what they think. The analysis should estimate what percentage of the meeting will actually drive changed behavior.
+
+**Four Assessment Dimensions:**
+
+1. **Decision yield vs. airtime**
+   - How many resolved decisions came out relative to total time spent?
+   - A high-performing meeting front-loads decisions and uses remaining time to stress-test them, not discover them.
+   - Flag: Low yield = lots of discussion, few concrete outcomes.
+
+2. **Data readiness**
+   - Were the right inputs available before the meeting started?
+   - Identify discussion that was structurally unresolvable because blocking information wasn't in the room.
+   - Flag: Meeting convened before a critical input was available.
+
+3. **Circular discussion rate**
+   - How many times did the group revisit a point that had already reached a conclusion?
+   - Once is healthy (someone caught something). Twice suggests the conclusion wasn't clean. Three+ times indicates a facilitation problem or unresolved interpersonal dynamic.
+   - Flag: Topics revisited 3+ times without new information.
+
+4. **Intent vs. words**
+   - When someone raises a concern multiple times in different language, the stated concern probably isn't the real one.
+   - When someone shuts down hypotheticals but keeps generating them, there's anxiety underneath worth surfacing.
+   - Meetings that only operate at face value miss what's actually blocking progress.
+   - Flag: Patterns suggesting unstated concerns or blockers.
+
+**Output format:** Brief "Meeting Effectiveness" section with:
+- Overall effectiveness estimate (percentage of meeting that will change behavior)
+- 1-2 sentence assessment for each dimension that showed signal
+- Omit dimensions where there's insufficient evidence
+
+### Contribution Quality Analysis
+
+Include in internal-facing outputs only. Assesses individual contributions beyond surface-level participation metrics.
+
+**Anti-pattern: Volume ≠ Value**
+
+LLMs tend to equate airtime with importance. The templates must explicitly instruct the LLM to distinguish between:
+- **Airtime** — How much someone spoke
+- **Signal** — How much of what they said moved the conversation forward
+
+Someone speaking loudly, frequently, or over others may actually be:
+- Going in circles (repeating the same point without new information)
+- Asserting rather than persuading (stating positions without building cases)
+- Filling silence rather than adding value
+- Dominating without leading (controlling airtime without driving outcomes)
+
+**What to assess:**
+
+1. **Progress drivers**
+   - Who introduced ideas that were adopted?
+   - Who asked questions that unlocked stuck discussions?
+   - Who synthesized disparate points into actionable conclusions?
+   - Note: This person may have spoken very little.
+
+2. **Airtime vs. impact ratio**
+   - Flag participants with high airtime but low decision influence
+   - Highlight participants with low airtime but high impact (the quiet person whose single question changed the direction)
+   - **40% threshold**: Flag any speaker who consumed more than 40% of talk-time (research-backed threshold for healthy meetings)
+
+3. **Rhetorical patterns**
+   - Distinguish building a case (evidence → reasoning → conclusion) from assertion (repeating a position louder)
+   - Note when someone "wins" through persistence rather than persuasion
+   - Identify when volume or interruption substitutes for substance
+
+4. **Listening signals**
+   - Did participants build on others' points, or just wait for their turn?
+   - Were questions asked to understand, or to set up a rebuttal?
+   - Did anyone explicitly change their position based on discussion?
+
+**Output format:** Brief "Contribution Dynamics" section (content-dependent — include only if notable patterns detected):
+- Who drove progress (with evidence)
+- Airtime/impact mismatches worth noting
+- Patterns that may be affecting meeting effectiveness
+
+**Guidance for LLM:** Do not assume the person who spoke most was most valuable. Do not assume confident or loud statements are correct or important. Assess based on what actually moved the meeting toward outcomes.
+
+### Additional Signal Detection
+
+Include in internal-facing outputs only. These are content-dependent sections — include only when notable signals are detected.
+
+**1. Question Quality Analysis**
+
+Research shows question quality matters more than quantity (Gong: winners ask 15-16 questions vs. 20 for losers — interrogation-style backfires).
+
+Assess:
+- **Question types**: Clarifying (seeking understanding) vs. challenging (testing assumptions) vs. leading (steering toward predetermined answer)
+- **Question distribution**: Who asks questions vs. who only makes statements?
+- **Question response**: Were questions actually answered, or deflected?
+
+Flag:
+- Meetings with very few questions (passive acceptance risk)
+- Interrogation patterns (rapid-fire questions without listening to answers)
+- Important questions that went unanswered
+
+**2. Hedging Language Detection**
+
+Hedging words (might, could, perhaps, sort of, kind of, I think, it seems) indicate uncertainty, lack of commitment, or political positioning.
+
+Assess:
+- Who hedges frequently, and in what contexts?
+- Is hedging concentrated when disagreeing with specific people?
+- Does hedging correlate with topics that later surface as unresolved?
+
+Flag:
+- High hedging frequency from specific participants
+- Hedging patterns that suggest deferred disagreement rather than genuine uncertainty
+- Commitments made with heavy hedging ("I think we could probably try to...")
+
+**3. Convergence Quality Check**
+
+Research on hidden profiles shows groups often converge too quickly, missing unique information held by individuals. Rapid agreement without dissent is a warning sign.
+
+Assess:
+- Did the group explore alternatives before converging?
+- Was dissent expressed, or did everyone quickly align?
+- Did anyone with relevant expertise stay silent?
+
+Flag:
+- Rapid convergence without expressed dissent (groupthink risk)
+- Early preference anchoring (senior person states position, others fall in line)
+- Unique perspectives that went unexplored
+
+**4. Commitment Strength Assessment**
+
+44% of meeting action items are never completed. Vague commitments are a leading cause.
+
+Assess commitment clarity on a spectrum:
+- **Strong**: "I will deliver X by Friday" (clear verb, owner, deadline)
+- **Moderate**: "I'll look into that this week" (owner, rough timeline, vague deliverable)
+- **Weak**: "We should explore this" (no owner, no timeline)
+- **Empty**: "Someone needs to handle that" (diffusion of responsibility)
+
+Flag:
+- Commitments without clear owners
+- Commitments without deadlines
+- "We" commitments with no individual accountability
+- High ratio of weak/empty commitments to strong ones
+
+**5. Topic Drift Detection**
+
+Track when conversation wanders from stated agenda or goals.
+
+Assess:
+- Did discussion stay focused on the meeting's purpose?
+- Were tangents productive (uncovered important issues) or wasteful?
+- Who brought the conversation back on track?
+
+Flag:
+- Significant time spent on topics unrelated to meeting purpose
+- Repeated drift to the same off-topic issue (may indicate an unaddressed concern)
+- Meetings that never addressed their stated agenda
+
+**Output format:** Include relevant signals in a "Meeting Signals" section, grouped by category. Only include categories where notable patterns were detected.
+
+### Personal Performance Self-Assessment (Optional)
+
+An optional section that analyzes the user's own contribution when they participated in the meeting. Enables longitudinal self-improvement tracking.
+
+**Activation flow:**
+
+The template should include an explicit opt-in prompt at the start:
+
+```
+Before analyzing, I have a question:
+
+Would you like me to include a personal performance analysis of your own
+contribution to this meeting? This section analyzes your talk time, question
+quality, hedging patterns, and other behaviors to support self-improvement
+tracking over time.
+
+[ ] Yes, include my performance analysis
+[ ] No, skip this section
+
+If yes: What name or speaker label identifies you in the transcript?
+[Your name]: _______
+```
+
+Only include the self-assessment section if the user explicitly opts in AND provides their identifier. Otherwise, omit it entirely.
+
+**What to assess:**
+
+1. **Contribution metrics**
+   - Talk time percentage (approximate from transcript segment count)
+   - Questions asked (count and types: clarifying / challenging / leading)
+   - Ideas adopted (contributions that became decisions or action items)
+   - Progress driver identification (did they move things forward?)
+
+2. **Behavioral observations**
+   - Hedging instances (flagged hedging language from this speaker)
+   - Interruption patterns (interrupted others / was interrupted)
+   - Building vs. competing (referenced others' ideas or only pushed own)
+   - Commitment clarity (strong / moderate / vague commitments made)
+
+3. **Quality indicators**
+   - Listening signals (built on others' points, or waited to speak?)
+   - Position flexibility (changed view based on discussion?)
+   - Directness (said what they thought, or hedged around it?)
+
+4. **Patterns to watch**
+   - Any concerning patterns specific to this person's participation
+   - Behaviors that may be worth tracking across meetings
+
+**Output format:**
+
+```markdown
+## Your Contribution ([Speaker Name])
+
+### Metrics
+- Talk time: ~XX%
+- Questions asked: X (X clarifying, X challenging, X leading)
+- Ideas adopted: X
+- Progress driver: Yes/No — [brief evidence if yes]
+
+### Observations
+- **Hedging:** [None detected / X instances — context]
+- **Interruptions:** [Interrupted others X times / Was interrupted X times]
+- **Commitments:** [Strong/Moderate/Vague] — [examples]
+- **Listening:** [Built on others' points / Primarily advanced own ideas]
+
+### Patterns to Watch
+- [Specific observation relevant to self-improvement]
+- [Another observation if applicable]
+
+### Trackable Summary
+`XX% talk | XQ | X adopted | driver:[y/n] | hedge:X | commits:[s/m/v]`
+```
+
+**The Trackable Summary line** provides a consistent, compact format for longitudinal tracking. Users can copy this line to a personal tracking system (e.g., Obsidian) to compare across meetings over time.
+
+**Guidance for analysis:**
+
+- Be direct and honest — the purpose is self-improvement, not ego protection
+- Focus on observable behaviors, not personality judgments
+- Frame observations constructively (what to watch, not what's wrong)
+- Apply the same "volume ≠ value" principle — high talk time isn't automatically good or bad
+- Note both strengths and areas for growth
+
+### Potential Issues Detection
+
+Include in internal-facing outputs only. A dedicated section that surfaces risks which could derail progress if left unaddressed.
+
+**Categories to identify:**
+
+1. **Confusions**
+   - Moments where participants appeared to be talking past each other
+   - Terms or concepts used differently by different people
+   - Answers that didn't address the actual question asked
+
+2. **Misunderstandings**
+   - Apparent agreement that may be based on different interpretations
+   - Assumptions one party made that another party may not share
+   - Technical or domain terms that may have been misinterpreted
+
+3. **Hidden disagreements**
+   - Surface agreement with signals of underlying resistance (hedging language, qualified yeses, body language cues if noted)
+   - Topics where someone conceded quickly but may not actually be aligned
+   - Patterns of "agreeing to disagree" without explicit acknowledgment
+
+4. **Unresolved items**
+   - Decisions that were discussed but never explicitly closed
+   - Questions raised but not answered
+   - Items deferred without a clear plan to revisit
+   - Ambiguous outcomes ("we'll figure it out" without specifics)
+
+**Output format:** "Potential Issues" section listing items with:
+- Category label (Confusion / Misunderstanding / Hidden Disagreement / Unresolved)
+- Brief description of the issue
+- Evidence from the transcript (quote or paraphrase)
+- Suggested follow-up action where applicable
+
+Omit this section entirely if no potential issues were detected.
+
+### Format Requirements
+
+- Use markdown with minimal tables (prefer bullets and sections)
+- Tables only for structured data that genuinely benefits from tabular format
+- Output must be readable in email, Slack, and markdown renderers
+
+## Data Requirements
+
+### Template Metadata
+
+Each template file must include:
+- Template name and purpose
+- Target output sections (required vs. content-dependent)
+- Target length guidance
+- Dual-output specification (if applicable)
+
+### API Integration
+
+The existing `TEMPLATE_FILES` mapping in `backend/routers/analysis.py` must be updated:
+- No new template types needed (client-shareable is part of client template)
+- Template content changes only; API structure unchanged
+
+### Existing Templates to Modify
+
+| File | Changes |
+|------|---------|
+| `templates/sales_meeting_analysis.md` | Condense sections, add tiered system, add follow-up output, add effectiveness assessment |
+| `templates/client_meeting_analysis.md` | Condense sections, add tiered system, add client-shareable output, add effectiveness assessment |
+| `templates/other.md` | Condense sections, add tiered system, add effectiveness assessment |
+
+## Edge Cases
+
+### Insufficient Transcript Content
+
+**Scenario:** Transcript is too short or lacks substantive discussion for meaningful analysis.
+
+**Expected behavior:** LLM should:
+1. Still produce required sections with available information
+2. Explicitly note "Insufficient signal" for content-dependent sections rather than fabricating content
+3. Note in Meeting Effectiveness assessment that there's insufficient content to evaluate behavioral change potential
+
+### Mixed-Language Transcripts
+
+**Scenario:** Meeting transcript contains Thai, English, or mixed content.
+
+**Expected behavior:** Output should always be in English regardless of transcript language (existing behavior, maintain it).
+
+### No Decisions Made
+
+**Scenario:** Meeting was purely discussion with no explicit decisions.
+
+**Expected behavior:**
+- Decisions section should state "No explicit decisions made"
+- Effectiveness assessment should flag low decision yield vs. airtime
+- Client-shareable version should omit Decisions section entirely rather than showing "none"
+
+### Client-Shareable Content Safety
+
+**Scenario:** Internal analysis contains sensitive observations that shouldn't appear in client output.
+
+**Expected behavior:** Client-shareable output must never include:
+- Client sentiment analysis
+- Private/internal observations
+- Competitive or budget intelligence
+- Risk assessments about the client relationship
+- Potential Issues section (confusions, hidden disagreements, etc.)
+- Meeting Effectiveness assessment
+- Anything from a "Private Notes" equivalent section
+
+### Missing Action Item Details
+
+**Scenario:** Action items discussed but owners or deadlines not specified.
+
+**Expected behavior:**
+- List action items with "Owner: TBD" or "Deadline: TBD" rather than omitting
+- Effectiveness assessment should note this impacts decision yield (decisions without clear ownership are less likely to change behavior)
+- Client-shareable version should still include the action item with TBD markers
+
+### Potential Issues Confidence
+
+**Scenario:** LLM detects a possible hidden disagreement or misunderstanding but isn't certain.
+
+**Expected behavior:**
+- Include the observation with explicit uncertainty language ("may indicate," "possibly," "worth checking")
+- Provide the evidence that triggered the observation so the user can judge
+- Err on the side of surfacing potential issues rather than suppressing uncertain ones — a false positive is less costly than missing a real problem
+
+### Transcript-Only Limitations
+
+**Scenario:** Analysis requires interpreting tone, emotion, or non-verbal cues that aren't present in the transcript.
+
+**Expected behavior:**
+- Acknowledge when an assessment is limited by text-only analysis (e.g., "Based on word choice alone, this appears to be agreement, but tone could indicate otherwise")
+- Focus on linguistic signals available in text: word choice, hedging language, repetition patterns, question types, response lengths
+- Do not fabricate emotional interpretations — if the transcript doesn't support a reading, note insufficient signal
+- Flag moments where audio context would materially change the interpretation (e.g., "The phrase 'that's fine' appears 3 times from Speaker B — tone would clarify if this is genuine agreement")
+
+### Self-Assessment Speaker Not Found
+
+**Scenario:** User opts into self-assessment and provides a name, but that name doesn't match any speaker in the transcript.
+
+**Expected behavior:**
+- Inform the user that the name wasn't found in the transcript
+- List the speaker names/labels that ARE in the transcript
+- Ask the user to clarify which speaker they are
+- Do not guess or assume — wait for user confirmation
+
+### Self-Assessment Insufficient Data
+
+**Scenario:** User's identified speaker has very few segments in the transcript (e.g., spoke only 2-3 times).
+
+**Expected behavior:**
+- Still produce the self-assessment section
+- Note that limited data affects assessment accuracy
+- Focus on what CAN be observed from available segments
+- Omit metrics that require more data (e.g., "Talk time: ~5% — insufficient segments for detailed behavioral analysis")
+
+## Open Questions
+
+### For Engineering
+
+1. **Template versioning**: Should we version templates (e.g., `v2` suffix) during transition, or replace in-place? Users may have muscle memory with current output structure.
+
+2. **Output length enforcement**: The LLM may not reliably hit length targets. Should the prompt include explicit word count guidance, or rely on structural guidance alone?
+
+3. **Interpretive confidence calibration**: Both "intent vs. words" and "Potential Issues" require nuanced interpretation. The edge case says to err toward surfacing issues, but should the template also instruct the LLM to rate its confidence level for each observation?
+
+### For Product
+
+1. **Template selection UX**: With dual-output templates, should the frontend explain that client template now includes shareable output, or is the template description sufficient?
+
+2. **Feedback loop**: How will we know if the refined templates are working better? Should we add a simple thumbs-up/down on analysis output?
+
+## Related Specifications
+
+### Audio-Based Emotional Intelligence
+
+A separate spec (`docs/specs/audio-emotional-intelligence.md`) covers extracting emotional and prosodic features from audio recordings. This would significantly enhance the analysis capabilities defined in this spec by adding:
+- Emotional tone detection (frustration, confidence, uncertainty)
+- Prosodic analysis (volume patterns, pace, pitch)
+- Interaction patterns (interruptions, talking over)
+- Word-tone mismatches ("That's fine" said with frustration)
+
+The current spec's transcript-only analysis is limited to linguistic signals. Audio analysis would unlock a critical dimension that's currently lost.

--- a/templates/client_meeting_analysis.md
+++ b/templates/client_meeting_analysis.md
@@ -16,6 +16,7 @@
 | Meeting Effectiveness | Required | Internal only |
 | Project Status | Content-dependent | Include if progress/blockers discussed |
 | Technical Discussions | Content-dependent | Include if technical topics covered |
+| Client Sentiment | Content-dependent | Internal only; include if sentiment signals detected |
 | Contribution Dynamics | Content-dependent | Include if notable patterns |
 | Meeting Signals | Content-dependent | Include if notable signals detected |
 | Potential Issues | Content-dependent | Include if issues detected |
@@ -129,6 +130,14 @@ Extract key information for project management and follow-up. Target ~400-500 wo
 
 **Decisions:** [Technical decisions made]
 **Open:** [Topics needing more exploration]
+
+## Client Sentiment
+[CONTENT-DEPENDENT: Internal only — include if clear sentiment signals detected]
+
+- **Overall mood:** Positive / Neutral / Concerned / Frustrated
+- **Project confidence:** High / Moderate / Low
+- **Key concerns:** [What's on their mind?]
+- **Notable quotes:** "[Anything important worth remembering]"
 
 ## Contribution Dynamics
 [CONTENT-DEPENDENT: Include only if notable patterns detected]

--- a/templates/client_meeting_analysis.md
+++ b/templates/client_meeting_analysis.md
@@ -1,150 +1,220 @@
 # Client Meeting Analysis Template
 
-Use this prompt with a meeting transcription to extract decisions, action items, and project status.
+## Template Metadata
 
----
+**Purpose:** Extract project decisions, action items, and generate client-shareable summary
+**Target length:** Internal Analysis ~400-500 words | Client-Shareable Summary ~200-300 words
+**Output structure:** Dual-output (internal notes + external summary)
+
+### Section Classification
+
+| Section | Tier | Notes |
+|---------|------|-------|
+| Summary | Required | Always include |
+| Decisions | Required | Always include (note "none" if applicable) |
+| Action Items | Required | Always include |
+| Meeting Effectiveness | Required | Internal only |
+| Project Status | Content-dependent | Include if progress/blockers discussed |
+| Technical Discussions | Content-dependent | Include if technical topics covered |
+| Contribution Dynamics | Content-dependent | Include if notable patterns |
+| Meeting Signals | Content-dependent | Include if notable signals detected |
+| Potential Issues | Content-dependent | Include if issues detected |
+| Your Contribution | Content-dependent | Only if user opts in |
+| Client-Shareable Summary | Required | Always generate |
+
+### Client-Shareable Content Safety
+
+The Client-Shareable Summary must NEVER include:
+- Client sentiment analysis or mood assessments
+- Private observations about client behavior or politics
+- Risk assessments about the client relationship
+- Potential Issues section content
+- Meeting Effectiveness assessment
+- Contribution Dynamics analysis
+- Any content from internal-only sections
 
 ## Prompt
 
-You are analyzing a client meeting transcript for Nimble, a digital product consulting company. This is an ongoing engagement, and the meeting covers project status, planning, and/or problem-solving.
+You are analyzing a client meeting transcript for Nimble, a digital product consulting company. This is an ongoing engagement covering project status, planning, and/or problem-solving.
 
 **Client:** {{CLIENT_NAME}}
 **Project:** {{PROJECT_NAME}}
 **Attendees:** {{NAMES_AND_ROLES}}
 **Date:** {{DATE}}
 
+### Personal Performance Opt-In
+
+Before analyzing, I have a question:
+
+Would you like me to include a personal performance analysis of your own contribution to this meeting? This section analyzes your talk time, question quality, hedging patterns, and other behaviors to support self-improvement tracking over time.
+
+[ ] Yes, include my performance analysis
+[ ] No, skip this section
+
+If yes: What name or speaker label identifies you in the transcript?
+[Your name]: _______
+
 ### Instructions
 
-Extract key information for project management and follow-up. Be precise about what was decided vs. what was discussed vs. what remains open. Attribute action items to specific people with deadlines where mentioned.
+Extract key information for project management and follow-up. Target ~400-500 words for Internal Analysis and ~200-300 words for Client-Shareable Summary.
+
+**Key principles:**
+- Be precise: decided vs. discussed vs. open
+- Attribute action items to specific people with deadlines
+- Use "In this meeting..." not "This team has..." for single-meeting observations
+- Volume ≠ value: Don't assume the person who spoke most was most important
+- Omit content-dependent sections entirely if insufficient signal
+- Include confidence levels for interpretive observations (high/medium/low)
+
+**For commitment assessment, use this spectrum:**
+- **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
+- **Moderate:** "I'll look into that this week" (owner, rough timeline, vague deliverable)
+- **Weak:** "We should explore this" (no owner, no timeline)
+- **Empty:** "Someone needs to handle that" (diffusion of responsibility)
 
 ### Output Format
 
 ```markdown
-# Client Meeting: {{CLIENT_NAME}} — {{PROJECT_NAME}}
+# Internal Analysis: {{CLIENT_NAME}} — {{PROJECT_NAME}}
 
-**Date:** {{DATE}}
-**Duration:** [extracted from transcript]
-
-**Attendees:**
-- [Name, Role] — Nimble
-- [Name, Role] — Client
-
----
+**Date:** {{DATE}} | **Duration:** [from transcript]
+**Attendees:** [Names — Company]
 
 ## Summary
 
-[3-5 sentences: What was this meeting about? What's the headline? Any major shifts or concerns?]
+[3-5 sentences: Meeting purpose, headline outcome, any major shifts or concerns]
 
----
+## Decisions
 
-## Decisions Made
+| Decision | Context |
+|----------|---------|
+| [What was decided] | [Why, if discussed] |
 
-Explicit decisions that were agreed upon in this meeting:
-
-| # | Decision | Context/Rationale |
-|---|----------|-------------------|
-| 1 | [What was decided] | [Why, if discussed] |
-| 2 | [What was decided] | [Why, if discussed] |
-
----
+[If no decisions: "No explicit decisions made in this meeting."]
 
 ## Action Items
 
-### Nimble
+**Nimble:**
+- [Task] — Owner: [Name] — Due: [Date/TBD] — Strength: Strong/Moderate/Weak
 
-| # | Action | Owner | Deadline | Notes |
-|---|--------|-------|----------|-------|
-| 1 | [Task] | [Name] | [Date or "ASAP" or "TBD"] | [Context] |
-| 2 | [Task] | [Name] | [Date] | [Context] |
+**Client:**
+- [Task] — Owner: [Name] — Due: [Date/TBD] — Strength: Strong/Moderate/Weak
 
-### Client
+## Meeting Effectiveness
 
-| # | Action | Owner | Deadline | Notes |
-|---|--------|-------|----------|-------|
-| 1 | [Task] | [Name] | [Date] | [Context] |
-| 2 | [Task] | [Name] | [Date] | [Context] |
+**Behavioral change estimate:** [X]% of this meeting will drive changed actions
+- **Decision yield:** [Assessment if relevant — decisions made vs. time spent?]
+- **Data readiness:** [Assessment if relevant — was blocking information missing?]
+- **Circular discussion:** [Assessment if relevant — topics revisited without new info?]
+- **Intent vs. words:** [Assessment if relevant — signs of unstated concerns?] (Confidence: high/medium/low)
 
----
-
-## Open Questions
-
-Issues raised but not resolved — need follow-up or further discussion:
-
-| # | Question | Owner | Context |
-|---|----------|-------|---------|
-| 1 | [Question or unresolved issue] | [Who needs to answer] | [Background] |
-| 2 | [Question] | [Owner] | [Background] |
-
----
+[Omit dimensions with insufficient evidence]
 
 ## Project Status
+[CONTENT-DEPENDENT: Include only if progress or blockers discussed]
 
-### Progress Since Last Meeting
-[What was completed or advanced?]
+**Progress:** [What was completed or advanced]
 
-### Current Blockers
-| Blocker | Impact | Owner | Path to Resolution |
-|---------|--------|-------|-------------------|
-| [Issue] | High/Med/Low | [Name] | [What needs to happen] |
+**Blockers:**
+- [Issue] — Impact: High/Med/Low — Owner: [Name] — Resolution path: [What needs to happen]
 
-### Upcoming Milestones
-| Milestone | Target Date | Status | Risk Level |
-|-----------|-------------|--------|------------|
-| [Milestone] | [Date] | On Track / At Risk / Blocked | 🟢 / 🟡 / 🔴 |
+**Upcoming milestones:**
+- [Milestone] — Target: [Date] — Status: On Track / At Risk / Blocked
 
-### Scope Changes
-[Any changes to scope discussed? Additions, cuts, deferrals?]
-
-| Change | Type | Impact | Status |
-|--------|------|--------|--------|
-| [Feature/requirement] | Addition / Removal / Deferral | [Effort, timeline] | Agreed / Under Discussion |
-
----
+**Scope changes:** [Additions, removals, deferrals if discussed]
 
 ## Technical Discussions
+[CONTENT-DEPENDENT: Include only if technical topics covered]
 
-[Summarize any technical topics covered: architecture decisions, implementation approaches, tradeoffs discussed]
+**Decisions:** [Technical decisions made]
+**Open:** [Topics needing more exploration]
 
-### Decisions
-- [Technical decision 1]
-- [Technical decision 2]
+## Contribution Dynamics
+[CONTENT-DEPENDENT: Include only if notable patterns detected]
 
-### Still Under Discussion
-- [Topic needing more exploration]
+- **Progress drivers:** [Who moved things forward, with evidence]
+- **Airtime/impact mismatch:** [High airtime + low impact, or low airtime + high impact]
+- **40% threshold:** [Flag any speaker who consumed >40% of talk time]
+- **Patterns:** [Assertion vs. persuasion, listening signals, position changes]
 
----
+## Meeting Signals
+[CONTENT-DEPENDENT: Include only categories with notable patterns]
 
-## Risks & Concerns
+**Question quality:** [Types asked, distribution, unanswered questions]
+**Hedging patterns:** [Who hedges, in what contexts, correlation with unresolved topics]
+**Convergence quality:** [Did they explore alternatives? Early anchoring? Groupthink risk?]
+**Commitment clarity:** [Ratio of strong to weak commitments, accountability gaps]
+**Topic drift:** [Time on tangents, who brought it back, unaddressed agenda items]
 
-| Risk/Concern | Raised By | Severity | Mitigation |
-|--------------|-----------|----------|------------|
-| [Issue] | [Name] | High/Med/Low | [What we'll do about it] |
+## Potential Issues
+[CONTENT-DEPENDENT: Include only if issues detected]
 
----
+- **[Category]:** [Description] — Evidence: "[quote]" — Suggested follow-up: [Action]
 
-## Client Sentiment
-
-**Overall mood:** Positive / Neutral / Concerned / Frustrated
-**Confidence in project:** High / Moderate / Low
-**Key concerns:** [What's on their mind?]
-
-**Notable quotes:**
-> "[Anything important they said that's worth remembering]"
-
----
-
-## Context for Next Meeting
-
-[What should be prepared? What topics will we need to address?]
-
----
+Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 
 ## Private Notes
 
-[Anything not for client consumption: internal observations, concerns, politics to navigate, relationship dynamics]
-```
+[Internal observations not for client: relationship dynamics, concerns, politics to navigate]
+
+## Your Contribution ([Speaker Name])
+[CONTENT-DEPENDENT: Include only if user opted in AND speaker found in transcript]
+
+### Metrics
+- Talk time: ~XX%
+- Questions asked: X (X clarifying, X challenging, X leading)
+- Ideas adopted: X
+- Progress driver: Yes/No — [brief evidence]
+
+### Observations
+- **Hedging:** [None detected / X instances — context]
+- **Interruptions:** [Interrupted others X times / Was interrupted X times]
+- **Commitments:** [Strong/Moderate/Vague] — [examples]
+- **Listening:** [Built on others' points / Primarily advanced own ideas]
+
+### Patterns to Watch
+- [Specific observation for self-improvement]
+
+### Trackable Summary
+`XX% talk | XQ | X adopted | driver:[y/n] | hedge:X | commits:[s/m/v]`
 
 ---
+
+# Client-Shareable Summary
+
+[Professional summary suitable for emailing to clients, ~200-300 words]
+
+## Meeting Summary: {{PROJECT_NAME}}
+
+**Date:** {{DATE}}
+**Attendees:** [Names]
+
+### Overview
+
+[2-3 sentences: What we covered and key outcomes]
+
+### Decisions Made
+
+- [Decision 1]
+- [Decision 2]
+
+[Omit this section entirely if no decisions were made]
+
+### Action Items
+
+**Nimble will:**
+- [Task] — [Owner] — [Timeline]
+
+**[Client] will:**
+- [Task] — [Owner] — [Timeline]
+
+### Next Steps
+
+[What happens next, when we'll reconnect]
+
+---
+*Summary prepared by Nimble*
+```
 
 ## Transcript
 

--- a/templates/client_meeting_analysis.md
+++ b/templates/client_meeting_analysis.md
@@ -65,6 +65,7 @@ Extract key information for project management and follow-up. Target ~400-500 wo
 - Volume ≠ value: Don't assume the person who spoke most was most important
 - Omit content-dependent sections entirely if insufficient signal
 - Include confidence levels for interpretive observations (high/medium/low)
+- Acknowledge transcript-only limitations: When tone would materially affect interpretation (e.g., "that's fine" could be agreement or frustration), note that audio context would clarify
 
 **For commitment assessment, use this spectrum:**
 - **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
@@ -159,6 +160,9 @@ Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 
 ## Your Contribution ([Speaker Name])
 [CONTENT-DEPENDENT: Include only if user opted in AND speaker found in transcript]
+
+**If speaker not found:** Instead of this section, output:
+"I couldn't find '[provided name]' in the transcript. The speakers I found are: [list speaker names/labels]. Please clarify which speaker you are, and I'll regenerate the self-assessment."
 
 ### Metrics
 - Talk time: ~XX%

--- a/templates/other.md
+++ b/templates/other.md
@@ -1,61 +1,149 @@
 # General Meeting Analysis Template
 
-Use this prompt with a meeting transcription to generate a structured summary.
+## Template Metadata
+
+**Purpose:** Generate structured summary for any meeting type
+**Target length:** ~300-400 words
+**Output structure:** Single output (internal analysis)
+
+### Section Classification
+
+| Section | Tier | Notes |
+|---------|------|-------|
+| Summary | Required | Always include |
+| Decisions | Required | Always include (note "none" if applicable) |
+| Action Items | Required | Always include |
+| Meeting Effectiveness | Required | Always include |
+| Key Discussion Points | Content-dependent | Include if substantive topics discussed |
+| Contribution Dynamics | Content-dependent | Include if notable patterns |
+| Meeting Signals | Content-dependent | Include if notable signals detected |
+| Potential Issues | Content-dependent | Include if issues detected |
+| Your Contribution | Content-dependent | Only if user opts in |
 
 ## Prompt
 
-You are analyzing a meeting transcript. Extract the key information in a clear, actionable format.
+You are analyzing a meeting transcript. Extract key information in a clear, actionable format.
 
 **Attendees:** [identified from transcript]
 **Date:** [today or extracted from context]
 
+### Personal Performance Opt-In
+
+Before analyzing, I have a question:
+
+Would you like me to include a personal performance analysis of your own contribution to this meeting? This section analyzes your talk time, question quality, hedging patterns, and other behaviors to support self-improvement tracking over time.
+
+[ ] Yes, include my performance analysis
+[ ] No, skip this section
+
+If yes: What name or speaker label identifies you in the transcript?
+[Your name]: _______
+
 ### Instructions
 
-Analyze the transcript and produce a structured summary. Be specific — cite examples from the conversation where relevant. Focus on what was discussed, decided, and what needs to happen next.
+Analyze the transcript and produce a structured summary. Target ~300-400 words total.
+
+**Key principles:**
+- Focus on what was discussed, decided, and what needs to happen next
+- Cite evidence from the conversation where relevant
+- Use "In this meeting..." not "This group has..." for single-meeting observations
+- Volume ≠ value: Don't assume the person who spoke most was most important
+- Omit content-dependent sections entirely if insufficient signal
+- Include confidence levels for interpretive observations (high/medium/low)
+
+**For commitment assessment, use this spectrum:**
+- **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
+- **Moderate:** "I'll look into that this week" (owner, rough timeline, vague deliverable)
+- **Weak:** "We should explore this" (no owner, no timeline)
+- **Empty:** "Someone needs to handle that" (diffusion of responsibility)
 
 ### Output Format
 
 ```markdown
 # Meeting Summary
 
-**Date:** [Date]
-**Duration:** [extracted from transcript]
+**Date:** {{DATE}} | **Duration:** [from transcript]
 **Attendees:** [Names identified in transcript]
 
 ## Summary
 
-[3-5 sentences: What was this meeting about? What's the key takeaway?]
+[3-5 sentences: Meeting purpose, key takeaway, any notable outcomes]
 
-## Key Discussion Points
+## Decisions
 
-### [Topic 1]
-[Summary of what was discussed]
+| Decision | Context |
+|----------|---------|
+| [What was decided] | [Why or relevant context] |
 
-### [Topic 2]
-[Summary of what was discussed]
-
-## Decisions Made
-
-| # | Decision | Context |
-|---|----------|---------|
-| 1 | [What was decided] | [Why or relevant context] |
+[If no decisions: "No explicit decisions made in this meeting."]
 
 ## Action Items
 
-| # | Action | Owner | Deadline | Notes |
-|---|--------|-------|----------|-------|
-| 1 | [Task] | [Name] | [Date or TBD] | [Context] |
+- [Task] — Owner: [Name] — Due: [Date/TBD] — Strength: Strong/Moderate/Weak
 
-## Open Questions
+## Meeting Effectiveness
 
-| # | Question | Owner | Context |
-|---|----------|-------|---------|
-| 1 | [Unresolved question] | [Who needs to answer] | [Background] |
+**Behavioral change estimate:** [X]% of this meeting will drive changed actions
+- **Decision yield:** [Assessment if relevant — decisions made vs. time spent?]
+- **Data readiness:** [Assessment if relevant — was blocking information missing?]
+- **Circular discussion:** [Assessment if relevant — topics revisited without new info?]
+- **Intent vs. words:** [Assessment if relevant — signs of unstated concerns?] (Confidence: high/medium/low)
 
-## Notable Quotes
+[Omit dimensions with insufficient evidence]
 
-> "[Important or memorable statement]"
-> — [Speaker name]
+## Key Discussion Points
+[CONTENT-DEPENDENT: Include only if substantive topics discussed]
+
+### [Topic 1]
+[Summary of what was discussed and any conclusions]
+
+### [Topic 2]
+[Summary of what was discussed and any conclusions]
+
+## Contribution Dynamics
+[CONTENT-DEPENDENT: Include only if notable patterns detected]
+
+- **Progress drivers:** [Who moved things forward, with evidence]
+- **Airtime/impact mismatch:** [High airtime + low impact, or low airtime + high impact]
+- **40% threshold:** [Flag any speaker who consumed >40% of talk time]
+- **Patterns:** [Assertion vs. persuasion, listening signals, position changes]
+
+## Meeting Signals
+[CONTENT-DEPENDENT: Include only categories with notable patterns]
+
+**Question quality:** [Types asked, distribution, unanswered questions]
+**Hedging patterns:** [Who hedges, in what contexts, correlation with unresolved topics]
+**Convergence quality:** [Did they explore alternatives? Early anchoring? Groupthink risk?]
+**Commitment clarity:** [Ratio of strong to weak commitments, accountability gaps]
+**Topic drift:** [Time on tangents, who brought it back, unaddressed agenda items]
+
+## Potential Issues
+[CONTENT-DEPENDENT: Include only if issues detected]
+
+- **[Category]:** [Description] — Evidence: "[quote]" — Suggested follow-up: [Action]
+
+Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
+
+## Your Contribution ([Speaker Name])
+[CONTENT-DEPENDENT: Include only if user opted in AND speaker found in transcript]
+
+### Metrics
+- Talk time: ~XX%
+- Questions asked: X (X clarifying, X challenging, X leading)
+- Ideas adopted: X
+- Progress driver: Yes/No — [brief evidence]
+
+### Observations
+- **Hedging:** [None detected / X instances — context]
+- **Interruptions:** [Interrupted others X times / Was interrupted X times]
+- **Commitments:** [Strong/Moderate/Vague] — [examples]
+- **Listening:** [Built on others' points / Primarily advanced own ideas]
+
+### Patterns to Watch
+- [Specific observation for self-improvement]
+
+### Trackable Summary
+`XX% talk | XQ | X adopted | driver:[y/n] | hedge:X | commits:[s/m/v]`
 ```
 
 ## Transcript

--- a/templates/other.md
+++ b/templates/other.md
@@ -50,6 +50,7 @@ Analyze the transcript and produce a structured summary. Target ~300-400 words t
 - Volume ≠ value: Don't assume the person who spoke most was most important
 - Omit content-dependent sections entirely if insufficient signal
 - Include confidence levels for interpretive observations (high/medium/low)
+- Acknowledge transcript-only limitations: When tone would materially affect interpretation (e.g., "that's fine" could be agreement or frustration), note that audio context would clarify
 
 **For commitment assessment, use this spectrum:**
 - **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
@@ -126,6 +127,9 @@ Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 
 ## Your Contribution ([Speaker Name])
 [CONTENT-DEPENDENT: Include only if user opted in AND speaker found in transcript]
+
+**If speaker not found:** Instead of this section, output:
+"I couldn't find '[provided name]' in the transcript. The speakers I found are: [list speaker names/labels]. Please clarify which speaker you are, and I'll regenerate the self-assessment."
 
 ### Metrics
 - Talk time: ~XX%

--- a/templates/sales_meeting_analysis.md
+++ b/templates/sales_meeting_analysis.md
@@ -1,8 +1,28 @@
 # Sales Meeting Analysis Template
 
-Use this prompt with a meeting transcription to extract sales intelligence and next steps.
+## Template Metadata
 
----
+**Purpose:** Extract sales intelligence and generate prospect follow-up from sales conversations
+**Target length:** Sales Intelligence ~400-500 words | Prospect Follow-Up ~150-200 words
+**Output structure:** Dual-output (internal intelligence + external follow-up)
+
+### Section Classification
+
+| Section | Tier | Notes |
+|---------|------|-------|
+| TL;DR | Required | Always include |
+| Deal Snapshot | Required | Always include |
+| Pain Points & Needs | Required | Always include |
+| Commitments | Required | Always include |
+| Meeting Effectiveness | Required | Internal only |
+| Decision Making | Content-dependent | Include if buying process discussed |
+| Budget Signals | Content-dependent | Include if budget/pricing discussed |
+| Objections | Content-dependent | Include if concerns raised |
+| Contribution Dynamics | Content-dependent | Include if notable patterns |
+| Meeting Signals | Content-dependent | Include if notable signals detected |
+| Potential Issues | Content-dependent | Include if issues detected |
+| Your Contribution | Content-dependent | Only if user opts in |
+| Prospect Follow-Up | Required | Always generate |
 
 ## Prompt
 
@@ -13,163 +33,175 @@ You are analyzing a sales meeting transcript for Nimble, a digital product consu
 **Attendees:** {{NAMES_AND_ROLES}}
 **Date:** {{DATE}}
 
+### Personal Performance Opt-In
+
+Before analyzing, I have a question:
+
+Would you like me to include a personal performance analysis of your own contribution to this meeting? This section analyzes your talk time, question quality, hedging patterns, and other behaviors to support self-improvement tracking over time.
+
+[ ] Yes, include my performance analysis
+[ ] No, skip this section
+
+If yes: What name or speaker label identifies you in the transcript?
+[Your name]: _______
+
 ### Instructions
 
-Extract actionable sales intelligence from this conversation. Be specific with quotes and timestamps where relevant. Distinguish between what was explicitly stated vs. what you're inferring.
+Extract actionable sales intelligence from this conversation. Target ~400-500 words for Sales Intelligence and ~150-200 words for Prospect Follow-Up.
+
+**Key principles:**
+- Distinguish explicit statements from inferences (mark inferences clearly)
+- Use "In this meeting..." not "This prospect has..." for single-meeting observations
+- Volume ≠ value: Don't assume the person who spoke most was most important
+- Omit content-dependent sections entirely if insufficient signal (don't fabricate)
+- Include confidence levels for interpretive observations (high/medium/low)
+
+**For commitment assessment, use this spectrum:**
+- **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
+- **Moderate:** "I'll look into that this week" (owner, rough timeline, vague deliverable)
+- **Weak:** "We should explore this" (no owner, no timeline)
+- **Empty:** "Someone needs to handle that" (diffusion of responsibility)
 
 ### Output Format
 
 ```markdown
-# Sales Meeting: {{COMPANY_NAME}}
+# Sales Intelligence: {{COMPANY_NAME}}
 
-**Date:** {{DATE}}
-**Meeting type:** {{TYPE}}
-**Duration:** [extracted from transcript]
-
-**Attendees:**
-- [Name, Role] — Nimble
-- [Name, Role] — Prospect
-
----
+**Date:** {{DATE}} | **Type:** {{TYPE}} | **Duration:** [from transcript]
+**Attendees:** [Names — Company]
 
 ## TL;DR
 
-[3-4 sentences: What's the opportunity? Where are we in the process? What's the critical next step?]
-
----
+[3-4 sentences: Opportunity summary, current position, critical next step]
 
 ## Deal Snapshot
 
-| Field | Value |
-|-------|-------|
-| **Opportunity** | [Brief description of what they need] |
-| **Estimated size** | [If discussed: budget, team size, duration] |
-| **Timeline** | [When do they want to start? Deadline pressures?] |
-| **Stage** | Discovery / Qualified / Proposal Sent / Negotiation / Verbal Yes |
-| **Temperature** | 🔥 Hot / ☀️ Warm / ❄️ Cool |
-
----
+- **Opportunity:** [What they need]
+- **Size signals:** [Budget, team size, duration if discussed]
+- **Timeline:** [When they want to start, deadline pressures]
+- **Stage:** Discovery / Qualified / Proposal / Negotiation / Verbal Yes
+- **Temperature:** Hot / Warm / Cool
 
 ## Pain Points & Needs
 
-[What problems are they trying to solve? Why now?]
+[What problems are they solving? Why now?]
 
-| Pain Point | Severity | Quote/Evidence |
-|------------|----------|----------------|
-| [Issue 1] | High/Med/Low | "[Quote]" |
-| [Issue 2] | High/Med/Low | "[Quote]" |
+- [Pain point 1] — Severity: High/Med/Low — Evidence: "[quote or paraphrase]"
+- [Pain point 2] — Severity: High/Med/Low — Evidence: "[quote or paraphrase]"
 
-**Underlying motivation:**
-[What's really driving this? Business pressure, competitive threat, internal politics, new leadership?]
+**Underlying motivation:** [Business pressure, competitive threat, new leadership, etc.]
 
----
+## Commitments
+
+**We committed to:**
+- [Action] — Owner: [Name] — Due: [Date/TBD] — Strength: Strong/Moderate/Weak
+
+**They committed to:**
+- [Action] — Owner: [Name] — Due: [Date/TBD] — Strength: Strong/Moderate/Weak
+
+## Meeting Effectiveness
+
+**Behavioral change estimate:** [X]% of this meeting will drive changed actions
+- **Decision yield:** [Assessment if relevant — were decisions made relative to time spent?]
+- **Data readiness:** [Assessment if relevant — was blocking information missing?]
+- **Circular discussion:** [Assessment if relevant — topics revisited without new info?]
+- **Intent vs. words:** [Assessment if relevant — signs of unstated concerns?] (Confidence: high/medium/low)
+
+[Omit dimensions with insufficient evidence]
 
 ## Decision Making
+[CONTENT-DEPENDENT: Include only if buying process was discussed]
 
-**Decision maker(s):**
-- [Name, Role] — [What's their stake? What do they care about?]
-
-**Influencers:**
-- [Name, Role] — [Technical evaluator? Budget holder? End user?]
-
-**Buying process:**
-[What's their process? Who else needs to approve? Procurement involved?]
-
-**Competition:**
-[Are they talking to others? Who? How do we compare?]
-
----
+- **Decision maker(s):** [Name, Role — what they care about]
+- **Influencers:** [Name, Role — their stake]
+- **Process:** [Approvals needed, procurement, timeline]
+- **Competition:** [Who else they're talking to, how we compare]
 
 ## Budget Signals
+[CONTENT-DEPENDENT: Include only if budget/pricing discussed]
 
-| Signal | Interpretation |
-|--------|----------------|
-| [What was said/implied] | [What it means] |
+- [Signal] → [Interpretation]
+- **Range:** [Explicit or inferred]
+- **Budget owner:** [Who controls the money]
 
-**Budget range:** [Explicit or inferred]
-**Budget owner:** [Who controls the money?]
-**Fiscal considerations:** [End of quarter? Budget cycle? Approval thresholds?]
+## Objections
+[CONTENT-DEPENDENT: Include only if concerns were raised]
 
----
+- [Concern] — Severity: High/Med/Low — Our response: [How addressed] — Resolved: Yes/Partially/No
 
-## Objections & Concerns
+**Unspoken concerns:** [What they might worry about but didn't say] (Confidence: high/medium/low)
 
-| Objection | Severity | How We Addressed | Resolved? |
-|-----------|----------|------------------|-----------|
-| [Concern 1] | High/Med/Low | [Our response] | Yes/Partially/No |
-| [Concern 2] | High/Med/Low | [Our response] | Yes/Partially/No |
+## Contribution Dynamics
+[CONTENT-DEPENDENT: Include only if notable patterns detected]
 
-**Unspoken concerns:**
-[What might they be worried about but didn't say?]
+- **Progress drivers:** [Who moved things forward, with evidence]
+- **Airtime/impact mismatch:** [High airtime + low impact, or low airtime + high impact]
+- **40% threshold:** [Flag any speaker who consumed >40% of talk time]
+- **Patterns:** [Assertion vs. persuasion, listening signals, position changes]
 
----
+## Meeting Signals
+[CONTENT-DEPENDENT: Include only categories with notable patterns]
 
-## Sentiment Analysis
+**Question quality:** [Types asked, distribution, unanswered questions]
+**Hedging patterns:** [Who hedges, in what contexts, correlation with unresolved topics]
+**Convergence quality:** [Did they explore alternatives? Early anchoring? Groupthink risk?]
+**Commitment clarity:** [Ratio of strong to weak commitments, accountability gaps]
+**Topic drift:** [Time on tangents, who brought it back, unaddressed agenda items]
 
-### Overall Enthusiasm
-**Level:** High / Moderate / Low / Mixed
-**Evidence:** [What signals are you reading?]
+## Potential Issues
+[CONTENT-DEPENDENT: Include only if issues detected]
 
-### Reaction to Pricing/Scope
-**Level:** Comfortable / Cautious / Concerned / Not Discussed
-**Evidence:** [Specific reactions when costs came up]
+- **[Category]:** [Description] — Evidence: "[quote]" — Suggested follow-up: [Action]
 
-### Confidence in Nimble
-**Level:** High / Building / Skeptical / Unclear
-**Evidence:** [Trust signals, concerns about our capabilities]
+Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 
-### Urgency
-**Level:** Urgent / Normal / Low Priority / Unclear
-**Evidence:** [Timeline pressure, competing priorities]
+## Your Contribution ([Speaker Name])
+[CONTENT-DEPENDENT: Include only if user opted in AND speaker found in transcript]
 
-### Momentum
-**Trend:** Gaining / Steady / Losing / Stalled
-**Evidence:** [Are we moving forward or spinning?]
+### Metrics
+- Talk time: ~XX%
+- Questions asked: X (X clarifying, X challenging, X leading)
+- Ideas adopted: X
+- Progress driver: Yes/No — [brief evidence]
 
----
+### Observations
+- **Hedging:** [None detected / X instances — context]
+- **Interruptions:** [Interrupted others X times / Was interrupted X times]
+- **Commitments:** [Strong/Moderate/Vague] — [examples]
+- **Listening:** [Built on others' points / Primarily advanced own ideas]
 
-## What We Committed To
+### Patterns to Watch
+- [Specific observation for self-improvement]
 
-- [ ] [Action item 1] — Owner: [Name] — Due: [Date]
-- [ ] [Action item 2] — Owner: [Name] — Due: [Date]
-
----
-
-## What They Committed To
-
-- [ ] [Action item 1] — Owner: [Name] — Due: [Date]
-- [ ] [Action item 2] — Owner: [Name] — Due: [Date]
-
----
-
-## Key Quotes
-
-> "[Verbatim quote that's useful for proposal or follow-up]"
-> — [Name], [context]
-
-> "[Another key quote]"
-> — [Name], [context]
+### Trackable Summary
+`XX% talk | XQ | X adopted | driver:[y/n] | hedge:X | commits:[s/m/v]`
 
 ---
 
-## Strategic Notes
+# Prospect Follow-Up
 
-**What's working:**
-[What resonated? What should we double down on?]
+[Professional thank-you email format, ~150-200 words]
 
-**What to adjust:**
-[What fell flat? What should we do differently?]
+**Subject:** Following up on our conversation — {{COMPANY_NAME}} + Nimble
 
-**Risks to the deal:**
-[What could derail this?]
+Hi [Name],
 
-**Recommended next steps:**
-1. [Immediate action]
-2. [Follow-up action]
-3. [Preparation for next meeting]
+Thank you for taking the time to meet with us today. [1-2 sentences acknowledging what was discussed and showing you listened]
+
+**Key points we covered:**
+- [Point 1]
+- [Point 2]
+- [Point 3]
+
+**Next steps:**
+- [Our commitment with timeline]
+- [Their expected action if discussed]
+
+[Closing that matches the meeting tone — warm if warm, professional if formal]
+
+Best regards,
+[Your name]
 ```
-
----
 
 ## Transcript
 

--- a/templates/sales_meeting_analysis.md
+++ b/templates/sales_meeting_analysis.md
@@ -18,6 +18,7 @@
 | Decision Making | Content-dependent | Include if buying process discussed |
 | Budget Signals | Content-dependent | Include if budget/pricing discussed |
 | Objections | Content-dependent | Include if concerns raised |
+| Prospect Sentiment | Content-dependent | Include if sentiment signals detected |
 | Contribution Dynamics | Content-dependent | Include if notable patterns |
 | Meeting Signals | Content-dependent | Include if notable signals detected |
 | Potential Issues | Content-dependent | Include if issues detected |
@@ -131,6 +132,15 @@ Extract actionable sales intelligence from this conversation. Target ~400-500 wo
 - [Concern] — Severity: High/Med/Low — Our response: [How addressed] — Resolved: Yes/Partially/No
 
 **Unspoken concerns:** [What they might worry about but didn't say] (Confidence: high/medium/low)
+
+## Prospect Sentiment
+[CONTENT-DEPENDENT: Include only if clear sentiment signals detected]
+
+- **Enthusiasm:** High / Moderate / Low / Mixed — Evidence: [signals]
+- **Pricing reaction:** Comfortable / Cautious / Concerned / Not discussed
+- **Confidence in Nimble:** High / Building / Skeptical / Unclear
+- **Urgency:** Urgent / Normal / Low priority — Evidence: [timeline pressure, competing priorities]
+- **Momentum:** Gaining / Steady / Losing / Stalled
 
 ## Contribution Dynamics
 [CONTENT-DEPENDENT: Include only if notable patterns detected]

--- a/templates/sales_meeting_analysis.md
+++ b/templates/sales_meeting_analysis.md
@@ -55,6 +55,7 @@ Extract actionable sales intelligence from this conversation. Target ~400-500 wo
 - Volume ≠ value: Don't assume the person who spoke most was most important
 - Omit content-dependent sections entirely if insufficient signal (don't fabricate)
 - Include confidence levels for interpretive observations (high/medium/low)
+- Acknowledge transcript-only limitations: When tone would materially affect interpretation (e.g., "that's fine" could be agreement or frustration), note that audio context would clarify
 
 **For commitment assessment, use this spectrum:**
 - **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
@@ -157,6 +158,9 @@ Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 
 ## Your Contribution ([Speaker Name])
 [CONTENT-DEPENDENT: Include only if user opted in AND speaker found in transcript]
+
+**If speaker not found:** Instead of this section, output:
+"I couldn't find '[provided name]' in the transcript. The speakers I found are: [list speaker names/labels]. Please clarify which speaker you are, and I'll regenerate the self-assessment."
 
 ### Metrics
 - Talk time: ~XX%


### PR DESCRIPTION
Story: docs/specs/meeting-analysis-templates-refinement.md

## Summary

Refines the meeting analysis templates (sales, client, general) to be more concise and actionable while adding new analysis capabilities. Key changes:

- **Dual-output structure**: Sales template now generates both Sales Intelligence and Prospect Follow-Up; Client template generates Internal Analysis and Client-Shareable Summary
- **Tiered sections**: Required sections always appear; content-dependent sections only appear when relevant signals are detected
- **Meeting effectiveness assessment**: Four-dimension framework evaluating decision yield, data readiness, circular discussion rate, and intent vs. words
- **Contribution dynamics**: Analyzes who drove progress, airtime/impact mismatches, and the 40% talk-time threshold
- **Signal detection**: Question quality, hedging patterns, convergence quality, commitment strength, topic drift
- **Personal performance self-assessment**: Optional opt-in section with trackable summary format for longitudinal improvement tracking
- **Potential issues detection**: Surfaces confusions, misunderstandings, hidden disagreements, and unresolved items

## Approach

The templates are LLM prompt instructions (markdown files). No API or frontend changes were needed — the existing `/api/templates/{type}` endpoint serves the refined content unchanged.

Key design decisions:
- **In-place replacement**: Templates replaced directly without versioning, as the spec indicated "template content changes only"
- **Explicit word count guidance**: Added target lengths to help LLMs produce appropriately-sized output
- **Confidence levels**: Interpretive observations (intent vs. words, potential issues) include confidence markers
- **Content safety**: Client-shareable output explicitly excludes sentiment analysis, private observations, and internal assessments

## Verification

- Architect review: Passed (no Critical, Major, or Minor issues)
- QA verification: Passed after addressing two edge cases:
  1. Transcript-only limitations acknowledgment
  2. Self-assessment speaker-not-found handling
- Manual review of template structure against spec requirements