### PR TITLE
[#40] Fix language selection ignored during transcription

### DIFF
--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -89,7 +89,8 @@ def _run_transcription(meeting_id: str, job_id: str):
 
         # Transcribe
         job_queue.update_job(job_id, stage="transcribing", progress=20)
-        model = whisperx.load_model(WHISPER_MODEL, device, compute_type=compute_type)
+        lang = metadata.language if metadata.language and metadata.language != "auto" else None
+        model = whisperx.load_model(WHISPER_MODEL, device, compute_type=compute_type, language=lang)
 
         # Estimate audio duration for time-based progress during transcription
         audio_duration_sec = len(audio) / 16000  # whisperx uses 16kHz sample rate


### PR DESCRIPTION
## Summary

- Pass the user-selected language to `whisperx.load_model()` so the tokenizer is configured correctly
- Previously language was only passed to `model.transcribe()`, but WhisperX checks for it at model load time

Closes #40

## Test plan

- [ ] Upload audio with a specific language selected (e.g., English)
- [ ] Verify server logs no longer show "No language specified, language will be detected"
- [ ] Upload audio with "Auto-detect" selected and confirm auto-detection still works