### PR TITLE
[#38] Provide context with each meeting

### DIFF
--- a/backend/routers/meetings.py
+++ b/backend/routers/meetings.py
@@ -204,7 +204,7 @@ async def update_meeting(meeting_id: str, update: MeetingUpdate):
     if update.speakers is not None:
         metadata.speakers = update.speakers
     if update.context is not None:
-        metadata.context = update.context
+        metadata.context = update.context.strip()
 
     _save_metadata(metadata)
     return metadata

--- a/backend/routers/meetings.py
+++ b/backend/routers/meetings.py
@@ -82,6 +82,7 @@ async def create_meeting(
     language: str = Form("auto"),
     num_speakers: str = Form("auto"),
     preprocess_audio: str = Form("true"),
+    context: str = Form(""),
 ):
     # Validate file extension
     ext = Path(file.filename).suffix.lower()
@@ -135,6 +136,7 @@ async def create_meeting(
         preprocess_audio=effective_preprocess,
         status=MeetingStatus.PROCESSING,
         job_id=job.id,
+        context=context.strip(),
     )
     _save_metadata(metadata)
 
@@ -201,6 +203,8 @@ async def update_meeting(meeting_id: str, update: MeetingUpdate):
         metadata.type = update.type
     if update.speakers is not None:
         metadata.speakers = update.speakers
+    if update.context is not None:
+        metadata.context = update.context
 
     _save_metadata(metadata)
     return metadata

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -61,12 +61,14 @@ class MeetingMetadata(BaseModel):
     job_id: str | None = None
     speakers: dict[str, str] = Field(default_factory=dict)
     error: str | None = None
+    context: str = ""
 
 
 class MeetingUpdate(BaseModel):
     title: str | None = None
     type: MeetingType | None = None
     speakers: dict[str, str] | None = None
+    context: str | None = None
 
 
 class MeetingSummary(BaseModel):

--- a/docs/plans/38-meeting-context.md
+++ b/docs/plans/38-meeting-context.md
@@ -1,0 +1,66 @@
+# Plan: Provide context with each meeting
+
+**Story**: #38
+**Spec**: `docs/specs/meeting-context.md`
+**Branch**: `feature/38-meeting-context`
+**Date**: 2026-04-08
+**Mode**: Standard — straightforward CRUD addition, no complex logic needing TDD
+
+## Technical Decisions
+
+### TD-1: Context stored as plain string in metadata.json
+- **Context**: Need to persist free-text context per meeting
+- **Decision**: Add `context: str = ""` to MeetingMetadata Pydantic model
+- **Alternatives considered**: Separate context file per meeting — unnecessary complexity for a single string field
+
+### TD-2: Template placeholder approach for prompt injection
+- **Context**: Need to inject context into analysis prompts
+- **Decision**: Add `[MEETING CONTEXT]` placeholder in all templates, replace in frontend JS
+- **Alternatives considered**: Backend-side injection — would require API changes to pass context to template endpoint; frontend replacement is simpler and consistent with existing `[PASTE TRANSCRIPT HERE]` pattern
+
+## Files to Create or Modify
+
+- `backend/schemas.py` — Add `context` field to MeetingMetadata and MeetingUpdate
+- `backend/routers/meetings.py` — Accept `context` Form field in create_meeting, handle in update_meeting
+- `frontend/js/api.js` — Pass `context` param in createMeeting
+- `frontend/js/components/upload.js` — Add context textarea to upload form
+- `frontend/js/components/transcript-viewer.js` — Display editable context in meeting detail
+- `frontend/js/components/analysis-viewer.js` — Inject context into generated prompts
+- `templates/*.md` (all 5) — Add `[MEETING CONTEXT]` placeholder
+
+## Approach per AC
+
+### AC 1: Upload form has an optional "Context" textarea
+Add textarea after meeting type, before preprocessing checkbox. Send value in FormData.
+
+### AC 2: Context is saved in meeting metadata and returned by GET /api/meetings/{id}
+Add `context: str = ""` to MeetingMetadata. Accept `context` Form field in POST. GET already returns full metadata.
+
+### AC 3: Context is editable from the meeting detail view via PATCH
+Add `context: str | None = None` to MeetingUpdate. Render editable textarea in transcript-viewer with save-on-blur.
+
+### AC 4: Generated analysis prompts include a `## Meeting Context` section when context is non-empty
+Add `[MEETING CONTEXT]` placeholder in templates. In analysis-viewer.js, replace with context section or remove line.
+
+### AC 5: Existing meetings without context continue to work (empty default)
+Pydantic default `""` handles missing field in old metadata.json files.
+
+## Commit Sequence
+
+1. Add `context` field to backend schemas and API endpoint
+2. Add context textarea to upload form and API client
+3. Add context display/edit in meeting detail view
+4. Add `[MEETING CONTEXT]` placeholder to templates and inject context in analysis prompt generation
+
+## Risks and Trade-offs
+
+- No character limit on context field (per spec: user responsibility)
+- All templates must include the placeholder; new templates added later must follow suit
+
+## Deviations from Spec
+
+- None planned
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -373,6 +373,36 @@ body {
     color: var(--text-muted);
 }
 
+/* Meeting Context */
+.meeting-context-section {
+    margin-bottom: 20px;
+}
+
+.meeting-context-section label {
+    display: block;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}
+
+.meeting-context-section textarea {
+    width: 100%;
+    background: var(--bg-surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    resize: vertical;
+}
+
+.meeting-context-section textarea:focus {
+    outline: none;
+    border-color: var(--primary);
+}
+
 /* Audio Player */
 .audio-player {
     background: var(--bg-surface);

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -336,7 +336,8 @@ body {
 }
 
 .form-group input,
-.form-group select {
+.form-group select,
+.form-group textarea {
     width: 100%;
     padding: 10px 12px;
     background: var(--bg-surface);
@@ -348,9 +349,14 @@ body {
 }
 
 .form-group input:focus,
-.form-group select:focus {
+.form-group select:focus,
+.form-group textarea:focus {
     outline: none;
     border-color: var(--primary);
+}
+
+.form-group textarea {
+    resize: vertical;
 }
 
 .form-checkbox label {
@@ -371,36 +377,6 @@ body {
 .form-hint {
     font-size: 12px;
     color: var(--text-muted);
-}
-
-/* Meeting Context */
-.meeting-context-section {
-    margin-bottom: 20px;
-}
-
-.meeting-context-section label {
-    display: block;
-    font-size: 14px;
-    font-weight: 500;
-    color: var(--text-muted);
-    margin-bottom: 6px;
-}
-
-.meeting-context-section textarea {
-    width: 100%;
-    background: var(--bg-surface);
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 10px 12px;
-    font-size: 14px;
-    font-family: inherit;
-    resize: vertical;
-}
-
-.meeting-context-section textarea:focus {
-    outline: none;
-    border-color: var(--primary);
 }
 
 /* Audio Player */

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -11,7 +11,7 @@ const API = {
         return res.json();
     },
 
-    async createMeeting(file, title, meetingType, language, numSpeakers, preprocessAudio = true) {
+    async createMeeting(file, title, meetingType, language, numSpeakers, preprocessAudio = true, context = '') {
         const form = new FormData();
         form.append('file', file);
         form.append('title', title || '');
@@ -19,6 +19,7 @@ const API = {
         form.append('language', language || 'auto');
         form.append('num_speakers', numSpeakers || 'auto');
         form.append('preprocess_audio', preprocessAudio ? 'true' : 'false');
+        form.append('context', context || '');
         const res = await fetch('/api/meetings', { method: 'POST', body: form });
         if (!res.ok) {
             const err = await res.json();

--- a/frontend/js/components/analysis-viewer.js
+++ b/frontend/js/components/analysis-viewer.js
@@ -28,7 +28,14 @@ async function handleGeneratePrompt() {
     try {
         const result = await API.getTemplate(type);
         const transcript = buildPlainTextTranscript();
-        const prompt = result.template.replace('[PASTE TRANSCRIPT HERE]', transcript);
+        const context = getMeetingContext();
+        let prompt = result.template;
+        if (context) {
+            prompt = prompt.replace('[MEETING CONTEXT]', '## Meeting Context\n\n' + context);
+        } else {
+            prompt = prompt.replace('[MEETING CONTEXT]\n\n', '');
+        }
+        prompt = prompt.replace('[PASTE TRANSCRIPT HERE]', transcript);
 
         const container = document.getElementById('analysis-tab');
         renderPromptContent(container, prompt);
@@ -37,6 +44,11 @@ async function handleGeneratePrompt() {
         btn.disabled = false;
         btn.textContent = 'Generate Prompt';
     }
+}
+
+function getMeetingContext() {
+    const textarea = document.getElementById('meeting-context');
+    return textarea ? textarea.value.trim() : '';
 }
 
 function buildPlainTextTranscript() {

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -43,7 +43,7 @@ async function loadMeetingView(container, meetingId) {
                 ` : ''}
 
                 ${!isProcessing && !isError ? `
-                    <div class="meeting-context-section">
+                    <div class="form-group">
                         <label for="meeting-context">Context</label>
                         <textarea id="meeting-context" rows="3" placeholder="Add context about this meeting for better analysis...">${escapeHtml(meta.context || '')}</textarea>
                     </div>

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -160,7 +160,7 @@ function setupContextEditor(meetingId) {
     const textarea = document.getElementById('meeting-context');
     if (!textarea) return;
 
-    let savedValue = textarea.value;
+    let savedValue = textarea.value.trim();
 
     textarea.addEventListener('blur', async () => {
         const newValue = textarea.value.trim();

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -43,6 +43,11 @@ async function loadMeetingView(container, meetingId) {
                 ` : ''}
 
                 ${!isProcessing && !isError ? `
+                    <div class="meeting-context-section">
+                        <label for="meeting-context">Context</label>
+                        <textarea id="meeting-context" rows="3" placeholder="Add context about this meeting for better analysis...">${escapeHtml(meta.context || '')}</textarea>
+                    </div>
+
                     <div class="audio-player" id="audio-player">
                         <audio id="audio-element" preload="metadata"></audio>
                         <div class="player-controls">
@@ -89,6 +94,7 @@ async function loadMeetingView(container, meetingId) {
 
         if (!isProcessing && !isError && transcript) {
             setupAudioPlayer(meetingId);
+            setupContextEditor(meetingId);
             renderSegments(document.getElementById('transcript-tab'), transcript, meta, meetingId);
             setupScrollDetection();
         }
@@ -147,6 +153,25 @@ function setupAudioPlayer(meetingId) {
 
     speedSelect.addEventListener('change', () => {
         audio.playbackRate = parseFloat(speedSelect.value);
+    });
+}
+
+function setupContextEditor(meetingId) {
+    const textarea = document.getElementById('meeting-context');
+    if (!textarea) return;
+
+    let savedValue = textarea.value;
+
+    textarea.addEventListener('blur', async () => {
+        const newValue = textarea.value.trim();
+        if (newValue === savedValue) return;
+        try {
+            await API.updateMeeting(meetingId, { context: newValue });
+            savedValue = newValue;
+            showToast('Context saved');
+        } catch (err) {
+            showToast('Failed to save context', 'error');
+        }
     });
 }
 

--- a/frontend/js/components/upload.js
+++ b/frontend/js/components/upload.js
@@ -61,6 +61,10 @@ function renderUpload(container) {
                     <input type="text" id="speakers-input" placeholder="Auto" value="">
                 </div>
             </div>
+            <div class="form-group">
+                <label for="context-input">Context</label>
+                <textarea id="context-input" rows="3" placeholder="What is this meeting about? Any important context for analysis..."></textarea>
+            </div>
             <div class="form-group form-checkbox">
                 <label>
                     <input type="checkbox" id="preprocess-checkbox" checked>
@@ -148,8 +152,9 @@ async function handleUpload(e) {
         const language = document.getElementById('language-select').value;
         const numSpeakers = document.getElementById('speakers-input').value.trim() || 'auto';
         const preprocessAudio = document.getElementById('preprocess-checkbox').checked;
+        const context = document.getElementById('context-input').value.trim();
         requestNotificationPermission();
-        const result = await API.createMeeting(selectedFile, title, type, language, numSpeakers, preprocessAudio);
+        const result = await API.createMeeting(selectedFile, title, type, language, numSpeakers, preprocessAudio, context);
         App.navigate(`/meetings/${result.meeting_id}`);
     } catch (err) {
         showToast(err.message, 'error');

--- a/templates/client_meeting_analysis.md
+++ b/templates/client_meeting_analysis.md
@@ -231,4 +231,6 @@ Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 
 ## Transcript
 
+[MEETING CONTEXT]
+
 [PASTE TRANSCRIPT HERE]

--- a/templates/interview_analysis.md
+++ b/templates/interview_analysis.md
@@ -160,4 +160,6 @@ Analyze the transcript and produce a structured evaluation. Be specific — cite
 
 ## Transcript
 
+[MEETING CONTEXT]
+
 [PASTE TRANSCRIPT HERE]

--- a/templates/other.md
+++ b/templates/other.md
@@ -152,4 +152,6 @@ Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 
 ## Transcript
 
+[MEETING CONTEXT]
+
 [PASTE TRANSCRIPT HERE]

--- a/templates/prototype_scope.md
+++ b/templates/prototype_scope.md
@@ -119,4 +119,6 @@ Add:
 
 ## Transcript
 
+[MEETING CONTEXT]
+
 [PASTE TRANSCRIPT HERE]

--- a/templates/sales_meeting_analysis.md
+++ b/templates/sales_meeting_analysis.md
@@ -219,4 +219,6 @@ Best regards,
 
 ## Transcript
 
+[MEETING CONTEXT]
+
 [PASTE TRANSCRIPT HERE]


### PR DESCRIPTION
Story: [#38](https://github.com/nimblehq/audio-transcriber/issues/38)

## Summary

Add an optional free-text context field to meetings so users can describe what the meeting is about. This context is injected into analysis prompts, enabling the LLM to produce more focused and relevant analysis.

- Context textarea on upload form and editable in meeting detail view (saved on blur)
- `context` field persisted in `metadata.json` via Pydantic model with empty string default
- Analysis prompts include a `## Meeting Context` section when context is non-empty
- Backward compatible: existing meetings without context continue to work

## Approach

Context is stored as a plain string field in the existing `MeetingMetadata` Pydantic model with a default of `""`, which handles backward compatibility for old metadata files automatically. For prompt injection, a `[MEETING CONTEXT]` placeholder was added to all templates (matching the existing `[PASTE TRANSCRIPT HERE]` pattern), and the frontend replaces it with a formatted section or removes it when empty.

## Verification

- Ruff linting and formatting pass (`ruff check` + `ruff format --check`)
- Architect review passed (2 major consistency fixes applied during review)
- Manual verification steps:
  - Upload a meeting with and without context
  - Edit context from meeting detail view, verify save-on-blur
  - Generate analysis prompts with and without context
  - Load an existing meeting (pre-feature) to verify backward compatibility