### PR TITLE
[#39] Refine meeting analysis

### DIFF
--- a/docs/plans/39-refine-meeting-analysis.md
+++ b/docs/plans/39-refine-meeting-analysis.md
@@ -1,0 +1,57 @@
+# Plan: Refine Meeting Analysis
+
+**Story**: #39
+**Spec**: N/A
+**Branch**: feature/39-refine-meeting-analysis
+**Date**: 2026-04-28
+**Mode**: Standard — markdown prompt templates, no automated tests apply.
+
+## Technical Decisions
+
+### TD-1: Include heuristic guidance, not just observation
+- **Context**: The new signals (next-action initiator, banter) only become useful if the LLM weights them in its assessment, not just collects them.
+- **Decision**: Each new field includes a short heuristic note explaining the signal (e.g., "prospect-driven next steps = positive buying signal", "banter generally indicates engagement").
+- **Alternatives considered**: Collect the data points neutrally and let downstream readers interpret. Rejected — the issue body explicitly frames these as positive signals; encoding the heuristic makes the output actionable.
+
+### TD-2: Sales template gets both signals prominently; client/other get rapport only
+- **Context**: Issue #39 ties next-action driver specifically to sales context. For client meetings (existing engagement) it carries less buying-signal weight.
+- **Decision**: Sales template surfaces next-step driver in Deal Snapshot and rapport in Prospect Sentiment. Client template adds rapport to Client Sentiment + a lightweight next-step driver line in Action Items. Other template adds rapport only to Meeting Signals.
+- **Alternatives considered**: Add both fields uniformly across all templates. Rejected — would dilute the sales-specific intent and add length to non-sales outputs.
+
+### TD-3: Rapport stays content-dependent / part of existing sentiment sections
+- **Context**: Recent refinement spec emphasized reducing verbosity. New signals risk re-bloating output.
+- **Decision**: No new top-level sections — rapport piggybacks on existing Sentiment sections (sales, client) or Meeting Signals (other). Next-step driver is a single line inside Deal Snapshot / Action Items.
+- **Alternatives considered**: Add a dedicated "Engagement Signals" section. Rejected — adds structural overhead for two short fields.
+
+## Files to Create or Modify
+
+- `templates/sales_meeting_analysis.md` — add next-step driver to Deal Snapshot, rapport to Prospect Sentiment, update Section Classification, add heuristic to Key principles.
+- `templates/client_meeting_analysis.md` — add rapport to Client Sentiment, next-step driver line to Action Items.
+- `templates/other.md` — add rapport line to Meeting Signals.
+
+## Approach per AC
+
+The issue itself only carries two bullet points (no formal AC). They map directly:
+
+### "Who's pushing for next actions? For sales meetings, if it's the client, it's a positive."
+Sales template: Deal Snapshot gets `**Next-step driver:** Prospect / Us / Mutual — Evidence: ...`. Heuristic line in Key principles notes prospect-driven next steps as a positive buying signal. Client template gets a lighter version in Action Items.
+
+### "Banter is usually a good sign."
+Sales template: rapport line in Prospect Sentiment with banter as evidence example. Client template: rapport line in Client Sentiment. Other template: rapport line in Meeting Signals. All three include the heuristic that banter generally indicates engagement.
+
+## Commit Sequence
+
+1. `[#39] Add next-step driver and rapport signals to sales template`
+2. `[#39] Add rapport signal to client template`
+3. `[#39] Add rapport signal to general meeting template`
+4. `[#39] Add plan document for issue #39`
+
+## Risks and Trade-offs
+
+- Slight length increase contradicts the verbosity-reduction spec. Mitigation: each addition is a single line inside an existing section; rapport sections remain content-dependent (omit if no signal).
+- "Rapport" is interpretive. Mitigation: existing template principles already require confidence levels for interpretive observations — that guidance applies here.
+- Heuristic encoding risks LLM over-confirming the heuristic (confirmation bias). Mitigation: heuristics phrased as "generally" / "often", not "always".
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/templates/client_meeting_analysis.md
+++ b/templates/client_meeting_analysis.md
@@ -27,6 +27,8 @@
 
 The Client-Shareable Summary must NEVER include:
 - Client sentiment analysis or mood assessments
+- Rapport / banter assessments
+- Next-step driver attribution or engagement-signal interpretation (the client-shareable Action Items lists tasks only, never who drove them or what that signals)
 - Private observations about client behavior or politics
 - Risk assessments about the client relationship
 - Potential Issues section content

--- a/templates/client_meeting_analysis.md
+++ b/templates/client_meeting_analysis.md
@@ -12,11 +12,11 @@
 |---------|------|-------|
 | Summary | Required | Always include |
 | Decisions | Required | Always include (note "none" if applicable) |
-| Action Items | Required | Always include |
+| Action Items | Required | Always include; includes next-step driver as an engagement indicator |
 | Meeting Effectiveness | Required | Internal only |
 | Project Status | Content-dependent | Include if progress/blockers discussed |
 | Technical Discussions | Content-dependent | Include if technical topics covered |
-| Client Sentiment | Content-dependent | Internal only; include if sentiment signals detected |
+| Client Sentiment | Content-dependent | Internal only; include if sentiment signals detected; includes rapport / banter assessment |
 | Contribution Dynamics | Content-dependent | Include if notable patterns |
 | Meeting Signals | Content-dependent | Include if notable signals detected |
 | Potential Issues | Content-dependent | Include if issues detected |
@@ -68,6 +68,10 @@ Extract key information for project management and follow-up. Target ~400-500 wo
 - Include confidence levels for interpretive observations (high/medium/low)
 - Acknowledge transcript-only limitations: When tone would materially affect interpretation (e.g., "that's fine" could be agreement or frustration), note that audio context would clarify
 
+**Engagement heuristics (weight these in your assessment):**
+- **Who's pushing for next actions matters.** A client driving the next steps generally signals healthy engagement and momentum; if Nimble is consistently the only one proposing follow-ups, that may indicate cooling interest or unclear value.
+- **Banter generally indicates rapport.** Casual exchanges, jokes, and personal warmth typically reflect a healthy working relationship. Sterile, all-business meetings with no warmth can be an early signal of strain.
+
 **For commitment assessment, use this spectrum:**
 - **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
 - **Moderate:** "I'll look into that this week" (owner, rough timeline, vague deliverable)
@@ -95,6 +99,8 @@ Extract key information for project management and follow-up. Target ~400-500 wo
 [If no decisions: "No explicit decisions made in this meeting."]
 
 ## Action Items
+
+**Next-step driver:** Client / Nimble / Mutual — [who proposed or pushed for the next actions; client-driven generally indicates healthy engagement]
 
 **Nimble:**
 - [Task] — Owner: [Name] — Due: [Date/TBD] — Strength: Strong/Moderate/Weak
@@ -136,6 +142,7 @@ Extract key information for project management and follow-up. Target ~400-500 wo
 
 - **Overall mood:** Positive / Neutral / Concerned / Frustrated
 - **Project confidence:** High / Moderate / Low
+- **Rapport:** Strong / Building / Cool / Distant — Evidence: [banter, casual exchanges, personal warmth; banter generally indicates a healthy relationship]
 - **Key concerns:** [What's on their mind?]
 - **Notable quotes:** "[Anything important worth remembering]"
 

--- a/templates/other.md
+++ b/templates/other.md
@@ -52,6 +52,8 @@ Analyze the transcript and produce a structured summary. Target ~300-400 words t
 - Include confidence levels for interpretive observations (high/medium/low)
 - Acknowledge transcript-only limitations: When tone would materially affect interpretation (e.g., "that's fine" could be agreement or frustration), note that audio context would clarify
 
+**Engagement heuristic:** Banter, jokes, and casual personal exchanges generally indicate rapport and engagement. Surface this as a positive signal when present.
+
 **For commitment assessment, use this spectrum:**
 - **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
 - **Moderate:** "I'll look into that this week" (owner, rough timeline, vague deliverable)
@@ -117,6 +119,7 @@ Analyze the transcript and produce a structured summary. Target ~300-400 words t
 **Convergence quality:** [Did they explore alternatives? Early anchoring? Groupthink risk?]
 **Commitment clarity:** [Ratio of strong to weak commitments, accountability gaps]
 **Topic drift:** [Time on tangents, who brought it back, unaddressed agenda items]
+**Rapport / banter:** [Casual exchanges, jokes, personal warmth — generally a positive engagement signal when present]
 
 ## Potential Issues
 [CONTENT-DEPENDENT: Include only if issues detected]

--- a/templates/sales_meeting_analysis.md
+++ b/templates/sales_meeting_analysis.md
@@ -11,14 +11,14 @@
 | Section | Tier | Notes |
 |---------|------|-------|
 | TL;DR | Required | Always include |
-| Deal Snapshot | Required | Always include |
+| Deal Snapshot | Required | Always include; includes next-step driver as a buying-signal indicator |
 | Pain Points & Needs | Required | Always include |
 | Commitments | Required | Always include |
 | Meeting Effectiveness | Required | Internal only |
 | Decision Making | Content-dependent | Include if buying process discussed |
 | Budget Signals | Content-dependent | Include if budget/pricing discussed |
 | Objections | Content-dependent | Include if concerns raised |
-| Prospect Sentiment | Content-dependent | Include if sentiment signals detected |
+| Prospect Sentiment | Content-dependent | Include if sentiment signals detected; includes rapport / banter assessment |
 | Contribution Dynamics | Content-dependent | Include if notable patterns |
 | Meeting Signals | Content-dependent | Include if notable signals detected |
 | Potential Issues | Content-dependent | Include if issues detected |
@@ -58,6 +58,10 @@ Extract actionable sales intelligence from this conversation. Target ~400-500 wo
 - Include confidence levels for interpretive observations (high/medium/low)
 - Acknowledge transcript-only limitations: When tone would materially affect interpretation (e.g., "that's fine" could be agreement or frustration), note that audio context would clarify
 
+**Engagement heuristics (weight these in your assessment):**
+- **Prospect-driven next steps are a positive buying signal.** When the prospect is the one proposing or pushing for next actions, that generally indicates real intent to move forward. When we have to pull next steps out of them, that often signals weak interest.
+- **Banter generally indicates rapport and engagement.** Casual exchanges, jokes, personal asides, and warm openings/closings typically reflect a healthy conversation. Sterile, all-business meetings with no warmth often correlate with cool prospects.
+
 **For commitment assessment, use this spectrum:**
 - **Strong:** "I will deliver X by Friday" (clear verb, owner, deadline)
 - **Moderate:** "I'll look into that this week" (owner, rough timeline, vague deliverable)
@@ -83,6 +87,7 @@ Extract actionable sales intelligence from this conversation. Target ~400-500 wo
 - **Timeline:** [When they want to start, deadline pressures]
 - **Stage:** Discovery / Qualified / Proposal / Negotiation / Verbal Yes
 - **Temperature:** Hot / Warm / Cool
+- **Next-step driver:** Prospect / Us / Mutual — Evidence: [who proposed or pushed for the next actions; prospect-driven is a positive buying signal]
 
 ## Pain Points & Needs
 
@@ -141,6 +146,7 @@ Extract actionable sales intelligence from this conversation. Target ~400-500 wo
 - **Confidence in Nimble:** High / Building / Skeptical / Unclear
 - **Urgency:** Urgent / Normal / Low priority — Evidence: [timeline pressure, competing priorities]
 - **Momentum:** Gaining / Steady / Losing / Stalled
+- **Rapport:** Strong / Building / Cool / Distant — Evidence: [banter, jokes, personal exchanges, warm openings/closings; banter generally indicates engagement]
 
 ## Contribution Dynamics
 [CONTENT-DEPENDENT: Include only if notable patterns detected]

--- a/templates/sales_meeting_analysis.md
+++ b/templates/sales_meeting_analysis.md
@@ -87,7 +87,7 @@ Extract actionable sales intelligence from this conversation. Target ~400-500 wo
 - **Timeline:** [When they want to start, deadline pressures]
 - **Stage:** Discovery / Qualified / Proposal / Negotiation / Verbal Yes
 - **Temperature:** Hot / Warm / Cool
-- **Next-step driver:** Prospect / Us / Mutual — Evidence: [who proposed or pushed for the next actions; prospect-driven is a positive buying signal]
+- **Next-step driver:** Prospect / Us / Mutual — Evidence: [who proposed or pushed for the next actions; prospect-driven generally signals real intent to move forward]
 
 ## Pain Points & Needs
 


### PR DESCRIPTION
Story: [#39](https://github.com/nimblehq/audio-transcriber/issues/39)

## Summary

Adds two engagement signals to the meeting analysis prompt templates so the LLM surfaces them with explicit heuristics rather than as neutral data points.

- **Next-step driver** — who's pushing for next actions. In sales, prospect-driven next steps generally signal real intent to move forward; in client engagements, client-driven follow-ups generally indicate healthy momentum.
- **Rapport / banter** — banter, jokes, and casual exchanges generally indicate engagement; sterile, all-business meetings can signal cooling interest or strain.

## Approach

- Sales template (`templates/sales_meeting_analysis.md`): next-step driver added to Deal Snapshot; rapport added to Prospect Sentiment; both heuristics encoded in Key principles.
- Client template (`templates/client_meeting_analysis.md`): next-step driver added to internal Action Items; rapport added to Client Sentiment; both heuristics encoded in Key principles. Client-Shareable Content Safety list explicitly excludes rapport assessments and next-step driver attribution from the client-shareable output.
- General template (`templates/other.md`): rapport line added to Meeting Signals plus a brief heuristic in Key principles.
- Hedging language (\"generally\", \"typically\") is used throughout to discourage the LLM from over-asserting the heuristics.
- Plan persisted at `docs/plans/39-refine-meeting-analysis.md`.

No code paths changed — this is templates-only.

## Verification

- Architect review on the branch passed (one Critical client-shareable safety leak was identified and fixed by adding explicit exclusions for next-step driver and rapport to the safety list; one Minor hedging-consistency comment also addressed).
- No automated tests apply (LLM prompt templates).
- Manual verification: rendered each template and confirmed the new fields appear inside the documented sections, the heuristics are present in Key principles, and the Section Classification tables match the body changes.