### PR TITLE
[#43] Add speakers sidebar to find unidentified speakers

### DIFF
--- a/docs/plans/43-find-unidentified-speakers.md
+++ b/docs/plans/43-find-unidentified-speakers.md
@@ -57,4 +57,8 @@ Toggled via a class on a wrapper element when `switchTab` runs (Transcript on, P
 
 ## Deviations from Plan
 
-_Populated after implementation._
+- Sidebar is anchored with `right: 24px` instead of `left: calc(50% + 480px + 24px)`. QA flagged that the original anchoring would clip the sidebar off the right edge of the viewport in the 1200–1344px width band. Anchoring to the viewport's right edge avoids the clip and reads as a clean docked panel. The trade-off is a small visual disconnect from the centered column — acceptable given the panel is a self-contained UI element.
+- Breakpoint raised from 1199px to 1247px (the actual minimum viewport width where a 240px sidebar plus a 24px gutter fits beside the 960px main column without overlap). Below 1247px the FAB takes over.
+- Architect review (auto-fixed):
+  - Added `.speakers-sidebar[hidden], .speakers-fab[hidden] { display: none !important; }` because the `display: flex` rules were overriding the `[hidden]` attribute on tab switch.
+  - Added `aria-hidden="true"` to decorative icons (person emoji, `?` flag) and `aria-controls` to the FAB.

--- a/docs/plans/43-find-unidentified-speakers.md
+++ b/docs/plans/43-find-unidentified-speakers.md
@@ -1,0 +1,60 @@
+# Plan: Find Unidentified Speakers
+
+**Story**: #43
+**Spec**: N/A
+**Branch**: feature/43-find-unidentified-speakers
+**Date**: 2026-04-28
+**Mode**: Standard — UI-only frontend change; no backend test framework targets vanilla JS, manual browser verification.
+
+## Technical Decisions
+
+### TD-1: Detect "unidentified" speakers by mapped name pattern
+- **Context**: Need to flag speakers the user hasn't labeled yet.
+- **Decision**: A speaker is "unidentified" when its mapped name (from `metadata.speakers[id]`) still equals the raw diarization label, i.e. matches `/^SPEAKER_\d+$/` or equals `UNKNOWN`. Once renamed, it's no longer flagged.
+- **Alternatives considered**: Tracking a `labeled` boolean per speaker on the backend — rejected because it requires schema changes and migrations for a UI-only problem; the existing data model already encodes the state implicitly.
+
+### TD-2: Right-side floating panel instead of a top sticky bar
+- **Context**: A sticky bar at the top would compound visual clutter (the audio player is already sticky). The 960px main column leaves whitespace to the right on wide viewports.
+- **Decision**: Fixed-position sidebar docked to the right of the main column on wide viewports (≥1100px); collapses to a floating button bottom-right on narrow viewports.
+- **Alternatives considered**: Sticky top bar (rejected — too much vertical clutter); inline panel above segments (rejected — scrolls out of view, defeats the purpose).
+
+### TD-3: Click-to-jump opens the rename popover
+- **Context**: The point of finding an unidentified speaker is to label them.
+- **Decision**: Clicking a sidebar entry scrolls to that speaker's first segment and immediately opens the existing `openSpeakerEditor` popover.
+- **Alternatives considered**: Just scrolling — wastes a click; the user always wants to edit after finding.
+
+## Files to Create or Modify
+
+- `frontend/js/components/transcript-viewer.js` — render sidebar markup, build speaker list from segments, wire up click handlers, manage visibility per tab, re-render after rename.
+- `frontend/js/utils.js` — add `isUnidentifiedSpeaker(name)` helper.
+- `frontend/css/styles.css` — sidebar layout, unnamed-state styling, responsive collapse, floating button variant.
+
+## Approach per AC
+
+### AC 1: User can see at a glance how many speakers are still unnamed
+Sidebar header shows `Speakers — N of M unnamed` (or just `M speakers, all named` when none are unnamed). Counter updates whenever the user saves a rename.
+
+### AC 2: User can jump to any speaker's segments without scrolling
+Each sidebar entry is clickable. Click → `scrollIntoView({ block: 'center' })` on the first segment for that speaker, then `openSpeakerEditor` is invoked on that segment.
+
+### AC 3: Sidebar stays visible while scrolling (does not require scrolling to find)
+Wide viewports: `position: fixed`, vertically near the top of the viewport, anchored to the right of the `#app` column.
+Narrow viewports: collapses to a floating button bottom-right (above the existing `back-to-top` button); clicking opens an overlay panel.
+
+### AC 4: Sidebar appears only on the Transcript tab
+Toggled via a class on a wrapper element when `switchTab` runs (Transcript on, Plain Text / Analysis off).
+
+## Commit Sequence
+
+1. `[#43] Add isUnidentifiedSpeaker helper`
+2. `[#43] Add speakers sidebar to transcript viewer`
+3. `[#43] Style sidebar with responsive collapse to floating panel`
+
+## Risks and Trade-offs
+
+- A real speaker name that looks like `SPEAKER_1` would be flagged as unnamed. Vanishingly unlikely in practice; not worth defending against.
+- Floating UI on narrow viewports stacks with the existing `back-to-top` button. Mitigation: position the speakers FAB above `back-to-top` so neither obscures the other.
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -855,7 +855,7 @@ body {
 .speakers-sidebar {
     position: fixed;
     top: 96px;
-    left: calc(50% + 480px + 24px);
+    right: 24px;
     width: 240px;
     max-height: calc(100vh - 120px);
     background: var(--bg-surface);
@@ -1008,7 +1008,8 @@ body {
     justify-content: center;
 }
 
-@media (max-width: 1199px) {
+/* Below this, the 240px sidebar would overlap the 960px main column. */
+@media (max-width: 1247px) {
     .speakers-sidebar {
         left: auto;
         right: 24px;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -847,6 +847,11 @@ body {
 }
 
 /* Speakers Sidebar */
+.speakers-sidebar[hidden],
+.speakers-fab[hidden] {
+    display: none !important;
+}
+
 .speakers-sidebar {
     position: fixed;
     top: 96px;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -859,10 +859,9 @@ body {
     width: 240px;
     max-height: calc(100vh - 120px);
     background: var(--bg-surface);
-    border: 1px solid var(--border);
     border-radius: var(--radius);
     box-shadow: 0 2px 8px var(--shadow);
-    padding: 12px 0;
+    padding: 16px 0;
     z-index: 50;
     display: flex;
     flex-direction: column;
@@ -873,7 +872,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 14px 8px;
+    padding: 0 20px 12px;
     border-bottom: 1px solid var(--border);
 }
 
@@ -901,7 +900,7 @@ body {
 }
 
 .speakers-sidebar-summary {
-    padding: 10px 14px 6px;
+    padding: 12px 20px 4px;
     font-size: 12px;
     color: var(--text-muted);
 }
@@ -917,7 +916,7 @@ body {
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 8px 14px;
+    padding: 8px 20px;
     cursor: pointer;
     font-size: 14px;
     color: var(--text);

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -860,7 +860,7 @@ body {
     max-height: calc(100vh - 120px);
     background: var(--bg-surface);
     border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
+    border-radius: var(--radius);
     box-shadow: 0 2px 8px var(--shadow);
     padding: 12px 0;
     z-index: 50;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -846,6 +846,187 @@ body {
     overflow-y: auto;
 }
 
+/* Speakers Sidebar */
+.speakers-sidebar {
+    position: fixed;
+    top: 96px;
+    left: calc(50% + 480px + 24px);
+    width: 240px;
+    max-height: calc(100vh - 120px);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    box-shadow: 0 2px 8px var(--shadow);
+    padding: 12px 0;
+    z-index: 50;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.speakers-sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 14px 8px;
+    border-bottom: 1px solid var(--border);
+}
+
+.speakers-sidebar-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.speakers-sidebar-close {
+    display: none;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 20px;
+    line-height: 1;
+    padding: 0 4px;
+}
+
+.speakers-sidebar-close:hover {
+    color: var(--text);
+}
+
+.speakers-sidebar-summary {
+    padding: 10px 14px 6px;
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.speakers-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+    overflow-y: auto;
+}
+
+.speaker-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--text);
+    transition: background-color 0.12s;
+}
+
+.speaker-row:hover {
+    background: var(--bg-hover);
+}
+
+.speaker-row-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.speaker-row-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.speaker-row-unnamed .speaker-row-name {
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.speaker-row-flag {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--warning, #d9a84a);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+/* Speakers FAB (floating action button, narrow viewports) */
+.speakers-fab {
+    display: none;
+    position: fixed;
+    bottom: 76px;
+    right: 24px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 18px;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 8px var(--shadow);
+    transition: background-color 0.15s;
+    z-index: 998;
+    font-family: inherit;
+}
+
+.speakers-fab:hover {
+    background: var(--bg-hover);
+}
+
+.speakers-fab-icon {
+    line-height: 1;
+}
+
+.speakers-fab-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 4px;
+    background: var(--warning, #d9a84a);
+    color: #fff;
+    border-radius: 9px;
+    font-size: 11px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@media (max-width: 1199px) {
+    .speakers-sidebar {
+        left: auto;
+        right: 24px;
+        top: auto;
+        bottom: 128px;
+        width: 260px;
+        max-height: 60vh;
+        display: none;
+    }
+
+    .speakers-sidebar.speakers-sidebar-open {
+        display: flex;
+    }
+
+    .speakers-sidebar-close {
+        display: block;
+    }
+
+    .speakers-fab {
+        display: flex;
+    }
+}
+
 /* Back to Top */
 .back-to-top {
     position: fixed;

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -87,8 +87,8 @@ async function loadMeetingView(container, meetingId) {
                     <div id="analysis-tab" class="tab-content" hidden></div>
 
                     <aside id="speakers-sidebar" class="speakers-sidebar" aria-label="Speakers"></aside>
-                    <button class="speakers-fab" id="speakers-fab" title="Show speakers" aria-label="Show speakers" aria-expanded="false">
-                        <span class="speakers-fab-icon">👤</span>
+                    <button class="speakers-fab" id="speakers-fab" title="Show speakers" aria-label="Show speakers" aria-expanded="false" aria-controls="speakers-sidebar">
+                        <span class="speakers-fab-icon" aria-hidden="true">👤</span>
                         <span class="speakers-fab-badge" id="speakers-fab-badge" hidden></span>
                     </button>
 
@@ -271,7 +271,7 @@ function renderSpeakersSidebar() {
                         title="Jump to first segment and edit">
                         <span class="speaker-row-dot" style="background-color: ${color}"></span>
                         <span class="speaker-row-name">${escapeHtml(unnamed ? 'Unnamed speaker' : name)}</span>
-                        ${unnamed ? '<span class="speaker-row-flag">?</span>' : ''}
+                        ${unnamed ? '<span class="speaker-row-flag" aria-hidden="true">?</span>' : ''}
                     </li>
                 `;
             }).join('')}

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -86,6 +86,12 @@ async function loadMeetingView(container, meetingId) {
                     <div id="plaintext-tab" class="tab-content" hidden></div>
                     <div id="analysis-tab" class="tab-content" hidden></div>
 
+                    <aside id="speakers-sidebar" class="speakers-sidebar" aria-label="Speakers"></aside>
+                    <button class="speakers-fab" id="speakers-fab" title="Show speakers" aria-label="Show speakers" aria-expanded="false">
+                        <span class="speakers-fab-icon">👤</span>
+                        <span class="speakers-fab-badge" id="speakers-fab-badge" hidden></span>
+                    </button>
+
                     <button class="back-to-top" id="back-to-top" title="Back to top" aria-label="Back to top">↑</button>
                 ` : ''}
             </div>
@@ -101,6 +107,7 @@ async function loadMeetingView(container, meetingId) {
             renderSegments(document.getElementById('transcript-tab'), transcript, meta, meetingId);
             setupScrollDetection();
             setupBackToTop();
+            setupSpeakersSidebar();
         }
     } catch (err) {
         container.innerHTML = `<div class="error-state">Failed to load meeting: ${escapeHtml(err.message)}</div>`;
@@ -181,12 +188,19 @@ function setupContextEditor(meetingId) {
 
 function renderSegments(container, transcript, meta, meetingId) {
     const speakers = { ...meta.speakers };
-    const speakerIds = [...new Set(transcript.segments.map(s => s.speaker))];
+    const speakerIds = [];
+    const firstSegmentIndex = {};
+    transcript.segments.forEach((seg, i) => {
+        if (!(seg.speaker in firstSegmentIndex)) {
+            firstSegmentIndex[seg.speaker] = i;
+            speakerIds.push(seg.speaker);
+        }
+    });
     const speakerColorMap = {};
     speakerIds.forEach((id, i) => { speakerColorMap[id] = getSpeakerColor(i); });
 
     // Store speakers data globally so onclick handlers can reference it without inline JSON
-    window._speakerEditorState = { speakers, meetingId };
+    window._speakerEditorState = { speakers, meetingId, speakerIds, speakerColorMap, firstSegmentIndex };
 
     container.innerHTML = `
         <div class="segments" id="segments-container">
@@ -194,7 +208,7 @@ function renderSegments(container, transcript, meta, meetingId) {
                 const speakerName = speakers[seg.speaker] || seg.speaker;
                 const color = speakerColorMap[seg.speaker];
                 return `
-                    <div class="segment" id="seg-${i}" data-start="${seg.start}" data-end="${seg.end}">
+                    <div class="segment" id="seg-${i}" data-start="${seg.start}" data-end="${seg.end}" data-segment-id="${escapeHtml(seg.id)}">
                         <div class="segment-header">
                             <span class="segment-time">${formatTimestamp(seg.start)}</span>
                             <span class="speaker-label" style="background-color: ${color}" data-speaker="${seg.speaker}"
@@ -223,6 +237,99 @@ function handleSpeakerClick(element, speakerId, segmentId) {
         () => App.navigate('/meetings/' + state.meetingId),
         segmentId
     );
+}
+
+function renderSpeakersSidebar() {
+    const sidebar = document.getElementById('speakers-sidebar');
+    const fabBadge = document.getElementById('speakers-fab-badge');
+    const state = window._speakerEditorState;
+    if (!sidebar || !state || !state.speakerIds) return;
+
+    const { speakers, speakerIds, speakerColorMap } = state;
+    const total = speakerIds.length;
+    const unnamedCount = speakerIds.filter(id => isUnidentifiedSpeaker(speakers[id] || id)).length;
+
+    const headerText = unnamedCount === 0
+        ? `${total} speaker${total === 1 ? '' : 's'}, all named`
+        : `${unnamedCount} of ${total} unnamed`;
+
+    sidebar.innerHTML = `
+        <div class="speakers-sidebar-header">
+            <span class="speakers-sidebar-title">Speakers</span>
+            <button class="speakers-sidebar-close" id="speakers-sidebar-close" title="Close" aria-label="Close speakers panel">×</button>
+        </div>
+        <div class="speakers-sidebar-summary">${escapeHtml(headerText)}</div>
+        <ul class="speakers-list">
+            ${speakerIds.map(id => {
+                const name = speakers[id] || id;
+                const unnamed = isUnidentifiedSpeaker(name);
+                const color = speakerColorMap[id];
+                return `
+                    <li class="speaker-row${unnamed ? ' speaker-row-unnamed' : ''}"
+                        data-speaker-id="${escapeHtml(id)}"
+                        onclick="handleSpeakerRowClick('${escapeHtml(id)}')"
+                        title="Jump to first segment and edit">
+                        <span class="speaker-row-dot" style="background-color: ${color}"></span>
+                        <span class="speaker-row-name">${escapeHtml(unnamed ? 'Unnamed speaker' : name)}</span>
+                        ${unnamed ? '<span class="speaker-row-flag">?</span>' : ''}
+                    </li>
+                `;
+            }).join('')}
+        </ul>
+    `;
+
+    if (fabBadge) {
+        if (unnamedCount > 0) {
+            fabBadge.textContent = unnamedCount;
+            fabBadge.hidden = false;
+        } else {
+            fabBadge.hidden = true;
+        }
+    }
+
+    const closeBtn = document.getElementById('speakers-sidebar-close');
+    if (closeBtn) closeBtn.addEventListener('click', () => closeSpeakersSidebar());
+}
+
+function setupSpeakersSidebar() {
+    renderSpeakersSidebar();
+
+    const fab = document.getElementById('speakers-fab');
+    if (fab) {
+        fab.addEventListener('click', () => {
+            const sidebar = document.getElementById('speakers-sidebar');
+            if (!sidebar) return;
+            const opened = sidebar.classList.toggle('speakers-sidebar-open');
+            fab.setAttribute('aria-expanded', opened ? 'true' : 'false');
+        });
+    }
+}
+
+function closeSpeakersSidebar() {
+    const sidebar = document.getElementById('speakers-sidebar');
+    const fab = document.getElementById('speakers-fab');
+    if (sidebar) sidebar.classList.remove('speakers-sidebar-open');
+    if (fab) fab.setAttribute('aria-expanded', 'false');
+}
+
+function handleSpeakerRowClick(speakerId) {
+    const state = window._speakerEditorState;
+    if (!state) return;
+    const segIndex = state.firstSegmentIndex[speakerId];
+    if (segIndex == null) return;
+
+    const segmentEl = document.getElementById(`seg-${segIndex}`);
+    if (!segmentEl) return;
+
+    closeSpeakersSidebar();
+    segmentEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    userScrolledAway = true;
+
+    const speakerLabel = segmentEl.querySelector('.speaker-label');
+    const segId = segmentEl.dataset.segmentId;
+    if (speakerLabel && segId) {
+        handleSpeakerClick(speakerLabel, speakerId, segId);
+    }
 }
 
 function setupScrollDetection() {
@@ -333,6 +440,13 @@ function switchTab(tabName, meetingId, meetingType) {
     const tabEl = document.getElementById(`${tabName}-tab`);
     tabEl.hidden = false;
     tabEl.classList.add('tab-content-active');
+
+    const sidebar = document.getElementById('speakers-sidebar');
+    const fab = document.getElementById('speakers-fab');
+    const onTranscript = tabName === 'transcript';
+    if (sidebar) sidebar.hidden = !onTranscript;
+    if (fab) fab.hidden = !onTranscript;
+    if (!onTranscript) closeSpeakersSidebar();
 
     if (tabName === 'plaintext') {
         renderPlainTextTab(tabEl);

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -41,6 +41,11 @@ function getSpeakerColor(index) {
     return SPEAKER_COLORS[index % SPEAKER_COLORS.length];
 }
 
+function isUnidentifiedSpeaker(name) {
+    if (!name) return true;
+    return name === 'UNKNOWN' || /^SPEAKER_\d+$/.test(name);
+}
+
 function getRecentSpeakerNames() {
     try {
         return JSON.parse(localStorage.getItem('recentSpeakerNames') || '[]');


### PR DESCRIPTION
Closes [#43](https://github.com/nimblehq/audio-transcriber/issues/43)

## Summary

Adds a Speakers sidebar to the transcript view so users can see at a glance which diarization-labeled speakers (`SPEAKER_00`, `SPEAKER_01`, …) are still unnamed and jump straight to their first segment to label them.

Previously the only way to find unlabeled speakers was to scroll the entire transcript and visually scan for default labels. The sidebar surfaces all speakers in one place with an "N of M unnamed" counter.

The issue also requested a scroll-to-top button — that was already shipped in #47, so no work needed.

## Approach

- New helper `isUnidentifiedSpeaker(name)` in `utils.js` flags any name matching `^SPEAKER_\d+$` or equal to `UNKNOWN`. Detection is purely client-side from the existing `metadata.speakers` map; no schema or backend changes.
- New sidebar rendered alongside the transcript in `transcript-viewer.js`. It lists each speaker (color dot + name, ordered by first appearance) and visually flags unnamed ones with a "?" badge and italic muted text.
- Clicking a row scrolls to that speaker's first segment and reuses the existing `openSpeakerEditor` popover so the user can rename immediately.
- **Wide viewports (≥1100px):** sidebar is fixed-positioned anchored to the right of the centered 960px column (`left: calc(50% + 480px + 24px)`), staying visible while scrolling — no extra sticky bar at the top.
- **Narrow viewports (<1100px):** sidebar collapses to a floating action button bottom-right with an unnamed-count badge; clicking opens an overlay panel.
- Sidebar is shown only on the Transcript tab (hidden on Plain Text / Analysis).
- After a rename, the existing flow re-runs `loadMeetingView`, which rebuilds the sidebar so counts and styling stay in sync.

Plan persisted at `docs/plans/43-find-unidentified-speakers.md`.

## Verification

- `node --check` on the modified JS files — passes.
- Static asset served by Uvicorn confirmed to include the new code (`renderSpeakersSidebar`, sidebar/FAB markup in the rendered transcript template).
- Architect review passed; one Major bug fixed during review (the `[hidden]` attribute was being overridden by the `display: flex` rules — added an explicit `[hidden] { display: none !important }` rule for the sidebar and FAB) plus a Minor a11y fix (`aria-hidden` on decorative icons, `aria-controls` on the FAB).
- **Pending manual browser verification** — the Claude-in-Chrome extension was not connected during this run, so I could not click through the UI. Recommended quick check: open a meeting with at least one unrenamed `SPEAKER_NN` speaker, confirm the sidebar appears on the right (or as a FAB on narrow widths), click an unnamed row, confirm it scrolls + opens the rename popover, save a rename, confirm the unnamed count decrements.