### PR TITLE
[#50] Add prosodic feature extraction stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           pip install --upgrade pip
           pip install 'fastapi>=0.115.0' 'uvicorn[standard]>=0.34.0' 'python-multipart>=0.0.20' 'python-dotenv>=1.0.0'
           pip install 'pytest>=8.0.0' 'pytest-asyncio>=0.24.0' 'httpx>=0.27.0' 'pytest-cov>=6.0.0'
+          pip install 'praat-parselmouth>=0.4.7'
 
       - name: Run tests with coverage
         run: pytest --cov --cov-report=term-missing --cov-fail-under=80

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ data/meetings/
 
 # Virtual environment
 .venv/
+.lock
+uv.lock
 
 # Node
 node_modules/

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -33,6 +33,7 @@ class JobStage(str, Enum):
     ALIGNING = "aligning"
     DIARIZING = "diarizing"
     EMOTION_ANALYSIS = "emotion_analysis"
+    PROSODY_EXTRACTION = "prosody_extraction"
 
 
 class EmotionCategory(str, Enum):
@@ -61,10 +62,34 @@ class EmotionAnnotation(BaseModel):
     low_confidence: bool
 
 
+class ProsodyAnnotation(BaseModel):
+    segment_id: str
+    speaker: str
+    start: float
+    end: float
+    volume_mean: float
+    volume_variance: float
+    pitch_mean: float
+    pitch_variance: float
+    speaking_rate: float
+    pause_ratio: float
+
+
+class ProsodyUnavailable(BaseModel):
+    segment_id: str
+    reason: str
+
+
 class AudioAnalysis(BaseModel):
     status: AudioAnalysisStatus
     reason: str | None = None
+    emotion_status: AudioAnalysisStatus | None = None
+    emotion_reason: str | None = None
     emotions: list[EmotionAnnotation] = Field(default_factory=list)
+    prosody_status: AudioAnalysisStatus | None = None
+    prosody_reason: str | None = None
+    prosody: list[ProsodyAnnotation] = Field(default_factory=list)
+    prosody_unavailable: list[ProsodyUnavailable] = Field(default_factory=list)
 
 
 class TranscriptSegment(BaseModel):

--- a/backend/services/prosody_analyzer.py
+++ b/backend/services/prosody_analyzer.py
@@ -25,6 +25,7 @@ PAUSE_FRAME_DURATION = 0.025  # 25 ms frames
 
 REASON_NON_SPEECH = "non_speech"
 REASON_EXTRACTION_FAILED = "prosody_unavailable"
+REASON_TOO_SHORT = "too_short"
 
 
 class _Segment(Protocol):
@@ -133,22 +134,29 @@ class _RawFeatures:
         self.frame_rms = frame_rms
 
 
-def _extract_segment_features(audio_array, segment: _Segment, sampling_rate: int) -> _RawFeatures | None:
+class _TooShort:
+    """Sentinel: segment was too short to extract features from."""
+
+
+def _extract_segment_features(audio_array, segment: _Segment, sampling_rate: int):
     """Extract raw (un-normalized) features for one segment.
 
-    Returns None if the segment is too short to analyze.
+    Returns `_RawFeatures` on success or the `_TooShort` sentinel when the
+    segment is below the analyzable duration. The sentinel lets the caller
+    record an unavailable marker so every segment has either prosody data
+    or an explicit explanation (story #50 truth).
     """
     import numpy as np
 
     duration = segment.end - segment.start
     if duration < MIN_SEGMENT_SECONDS:
-        return None
+        return _TooShort
 
     start_idx = int(segment.start * sampling_rate)
     end_idx = int(segment.end * sampling_rate)
     chunk = np.asarray(audio_array, dtype=np.float64)[start_idx:end_idx]
     if chunk.size == 0:
-        return None
+        return _TooShort
 
     rms = _compute_rms(chunk)
 
@@ -227,7 +235,8 @@ def analyze_segments(
             unavailable.append(ProsodyUnavailable(segment_id=segment.id, reason=REASON_EXTRACTION_FAILED))
             continue
 
-        if features is None:
+        if features is _TooShort:
+            unavailable.append(ProsodyUnavailable(segment_id=segment.id, reason=REASON_TOO_SHORT))
             continue
 
         if _is_non_speech(features):

--- a/backend/services/prosody_analyzer.py
+++ b/backend/services/prosody_analyzer.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from typing import Protocol
+
+from backend.schemas import ProsodyAnnotation, ProsodyUnavailable
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_RATE = 16000
+MIN_SEGMENT_SECONDS = 0.3
+
+# Non-speech detection: a segment is excluded if its raw RMS sits below this
+# floor AND Praat's pitch tracker yielded zero voiced frames. Catches silence,
+# extended pauses, and hold tones reliably; pure music is rare in meeting
+# recordings and would still be reported as non-speech if it carries no pitch.
+NON_SPEECH_RMS_FLOOR = 1e-3
+
+# Pause detection: an intra-segment frame counts as silence when its RMS is
+# below this fraction of the segment's peak RMS. Tuned to capture deliberate
+# pauses while ignoring envelope ripple inside running speech.
+PAUSE_RMS_RATIO = 0.1
+PAUSE_FRAME_DURATION = 0.025  # 25 ms frames
+
+REASON_NON_SPEECH = "non_speech"
+REASON_EXTRACTION_FAILED = "prosody_unavailable"
+
+
+class _Segment(Protocol):
+    id: str
+    start: float
+    end: float
+    speaker: str
+    text: str
+
+
+def _compute_rms(chunk):
+    import numpy as np
+
+    arr = np.asarray(chunk, dtype=np.float64)
+    if arr.size == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(arr * arr)))
+
+
+def _compute_pitch_stats(chunk, sampling_rate: int) -> tuple[float, float, int]:
+    """Return (mean Hz, variance Hz^2, voiced_frame_count) using Praat."""
+    import numpy as np
+    import parselmouth
+
+    arr = np.asarray(chunk, dtype=np.float64)
+    if arr.size == 0:
+        return 0.0, 0.0, 0
+    sound = parselmouth.Sound(arr, sampling_frequency=sampling_rate)
+    pitch = sound.to_pitch()
+    freqs = pitch.selected_array["frequency"]
+    voiced = freqs[freqs > 0]
+    if voiced.size == 0:
+        return 0.0, 0.0, 0
+    return float(np.mean(voiced)), float(np.var(voiced)), int(voiced.size)
+
+
+def _compute_pause_ratio(chunk, sampling_rate: int) -> float:
+    """Fraction of the segment that's below the pause RMS threshold."""
+    import numpy as np
+
+    arr = np.asarray(chunk, dtype=np.float64)
+    if arr.size == 0:
+        return 0.0
+
+    frame_len = max(1, int(sampling_rate * PAUSE_FRAME_DURATION))
+    n_frames = arr.size // frame_len
+    if n_frames == 0:
+        return 0.0
+
+    trimmed = arr[: n_frames * frame_len].reshape(n_frames, frame_len)
+    frame_rms = np.sqrt(np.mean(trimmed * trimmed, axis=1))
+    peak = float(frame_rms.max())
+    if peak <= 0:
+        return 1.0
+    threshold = peak * PAUSE_RMS_RATIO
+    silent = int(np.sum(frame_rms < threshold))
+    return silent / n_frames
+
+
+def _compute_speaking_rate(text: str, duration: float) -> float:
+    if duration <= 0:
+        return 0.0
+    word_count = len(text.split())
+    return word_count / duration * 60.0
+
+
+class _RawFeatures:
+    __slots__ = (
+        "segment_id",
+        "speaker",
+        "start",
+        "end",
+        "rms",
+        "pitch_mean",
+        "pitch_variance",
+        "voiced_frames",
+        "speaking_rate",
+        "pause_ratio",
+        "frame_rms",
+    )
+
+    def __init__(
+        self,
+        segment_id: str,
+        speaker: str,
+        start: float,
+        end: float,
+        rms: float,
+        pitch_mean: float,
+        pitch_variance: float,
+        voiced_frames: int,
+        speaking_rate: float,
+        pause_ratio: float,
+        frame_rms,
+    ):
+        self.segment_id = segment_id
+        self.speaker = speaker
+        self.start = start
+        self.end = end
+        self.rms = rms
+        self.pitch_mean = pitch_mean
+        self.pitch_variance = pitch_variance
+        self.voiced_frames = voiced_frames
+        self.speaking_rate = speaking_rate
+        self.pause_ratio = pause_ratio
+        self.frame_rms = frame_rms
+
+
+def _extract_segment_features(audio_array, segment: _Segment, sampling_rate: int) -> _RawFeatures | None:
+    """Extract raw (un-normalized) features for one segment.
+
+    Returns None if the segment is too short to analyze.
+    """
+    import numpy as np
+
+    duration = segment.end - segment.start
+    if duration < MIN_SEGMENT_SECONDS:
+        return None
+
+    start_idx = int(segment.start * sampling_rate)
+    end_idx = int(segment.end * sampling_rate)
+    chunk = np.asarray(audio_array, dtype=np.float64)[start_idx:end_idx]
+    if chunk.size == 0:
+        return None
+
+    rms = _compute_rms(chunk)
+
+    # Frame-level RMS for pause ratio and to expose for non-speech detection
+    frame_len = max(1, int(sampling_rate * PAUSE_FRAME_DURATION))
+    n_frames = chunk.size // frame_len
+    if n_frames > 0:
+        trimmed = chunk[: n_frames * frame_len].reshape(n_frames, frame_len)
+        frame_rms = np.sqrt(np.mean(trimmed * trimmed, axis=1))
+    else:
+        frame_rms = np.array([rms])
+
+    pitch_mean, pitch_variance, voiced_frames = _compute_pitch_stats(chunk, sampling_rate)
+    pause_ratio = _compute_pause_ratio(chunk, sampling_rate)
+    speaking_rate = _compute_speaking_rate(segment.text, duration)
+
+    return _RawFeatures(
+        segment_id=segment.id,
+        speaker=segment.speaker,
+        start=segment.start,
+        end=segment.end,
+        rms=rms,
+        pitch_mean=pitch_mean,
+        pitch_variance=pitch_variance,
+        voiced_frames=voiced_frames,
+        speaking_rate=speaking_rate,
+        pause_ratio=pause_ratio,
+        frame_rms=frame_rms,
+    )
+
+
+def _is_non_speech(features: _RawFeatures) -> bool:
+    return features.rms < NON_SPEECH_RMS_FLOOR and features.voiced_frames == 0
+
+
+def _normalize_volume(features: list[_RawFeatures]) -> dict[str, tuple[float, float]]:
+    """Compute meeting-wide normalized (volume_mean, volume_variance) per segment."""
+    import numpy as np
+
+    if not features:
+        return {}
+
+    peak = max(f.rms for f in features)
+    if peak <= 0:
+        return {f.segment_id: (0.0, 0.0) for f in features}
+
+    out: dict[str, tuple[float, float]] = {}
+    for f in features:
+        normalized_frame_rms = np.asarray(f.frame_rms, dtype=np.float64) / peak
+        volume_mean = float(np.mean(normalized_frame_rms))
+        volume_variance = float(np.var(normalized_frame_rms))
+        out[f.segment_id] = (volume_mean, volume_variance)
+    return out
+
+
+def analyze_segments(
+    audio_array,
+    segments: Iterable[_Segment],
+    sampling_rate: int = SAMPLE_RATE,
+) -> tuple[list[ProsodyAnnotation], list[ProsodyUnavailable]]:
+    """Run prosodic feature extraction on each segment.
+
+    Returns a tuple of (prosody annotations, unavailable markers). Per-segment
+    failures are isolated — a single broken segment does not abort the batch.
+    Non-speech segments are reported as unavailable rather than producing
+    noise-level prosody values.
+    """
+    raw: list[_RawFeatures] = []
+    unavailable: list[ProsodyUnavailable] = []
+
+    for segment in segments:
+        try:
+            features = _extract_segment_features(audio_array, segment, sampling_rate)
+        except Exception:
+            logger.exception("Prosody extraction failed for segment %s", segment.id)
+            unavailable.append(ProsodyUnavailable(segment_id=segment.id, reason=REASON_EXTRACTION_FAILED))
+            continue
+
+        if features is None:
+            continue
+
+        if _is_non_speech(features):
+            unavailable.append(ProsodyUnavailable(segment_id=segment.id, reason=REASON_NON_SPEECH))
+            continue
+
+        raw.append(features)
+
+    normalized = _normalize_volume(raw)
+
+    annotations: list[ProsodyAnnotation] = []
+    for f in raw:
+        volume_mean, volume_variance = normalized.get(f.segment_id, (0.0, 0.0))
+        annotations.append(
+            ProsodyAnnotation(
+                segment_id=f.segment_id,
+                speaker=f.speaker,
+                start=f.start,
+                end=f.end,
+                volume_mean=round(volume_mean, 4),
+                volume_variance=round(volume_variance, 6),
+                pitch_mean=round(f.pitch_mean, 2),
+                pitch_variance=round(f.pitch_variance, 2),
+                speaking_rate=round(f.speaking_rate, 2),
+                pause_ratio=round(f.pause_ratio, 4),
+            )
+        )
+
+    return annotations, unavailable

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -43,32 +43,98 @@ def _is_cancelled(metadata_path: Path) -> bool:
         return False
 
 
-def _run_audio_analysis(
+def _run_emotion_analysis(
     job_id: str,
     audio,
-    segments: list[dict],
+    segment_models: list[TranscriptSegment],
     detected_language: str,
-) -> AudioAnalysis:
-    """Run SER on transcript segments. Returns an AudioAnalysis whose status
-    reflects whether the analysis ran, was skipped, or failed."""
+) -> tuple[AudioAnalysisStatus, str | None, list]:
+    """Run SER. Returns (status, reason, annotations)."""
     if detected_language != "en":
         logger.info("Skipping emotion analysis: language %s is not supported", detected_language)
-        return AudioAnalysis(
-            status=AudioAnalysisStatus.UNAVAILABLE,
-            reason=f"language_not_supported:{detected_language}",
-        )
+        return AudioAnalysisStatus.UNAVAILABLE, f"language_not_supported:{detected_language}", []
 
     try:
         job_queue.update_job(job_id, stage="emotion_analysis", progress=92)
 
         from backend.services.emotion_analyzer import analyze_segments
 
-        segment_models = [TranscriptSegment(**s) for s in segments]
         annotations = analyze_segments(audio_path=None, segments=segment_models, audio_array=audio)
-        return AudioAnalysis(status=AudioAnalysisStatus.COMPLETED, emotions=annotations)
+        return AudioAnalysisStatus.COMPLETED, None, annotations
     except Exception as e:
         logger.exception("Emotion analysis failed")
-        return AudioAnalysis(status=AudioAnalysisStatus.FAILED, reason=str(e))
+        return AudioAnalysisStatus.FAILED, str(e), []
+
+
+def _run_prosody_analysis(
+    job_id: str,
+    audio,
+    segment_models: list[TranscriptSegment],
+) -> tuple[AudioAnalysisStatus, str | None, list, list]:
+    """Run prosody extraction (language-agnostic, BR-2.1).
+
+    Returns (status, reason, annotations, unavailable_markers).
+    """
+    try:
+        job_queue.update_job(job_id, stage="prosody_extraction", progress=95)
+
+        from backend.services.prosody_analyzer import analyze_segments as analyze_prosody
+
+        annotations, unavailable = analyze_prosody(audio_array=audio, segments=segment_models)
+        return AudioAnalysisStatus.COMPLETED, None, annotations, unavailable
+    except Exception as e:
+        logger.exception("Prosody extraction failed")
+        return AudioAnalysisStatus.FAILED, str(e), [], []
+
+
+def _roll_up_status(*statuses: AudioAnalysisStatus) -> AudioAnalysisStatus:
+    """Combine per-stage statuses into the pipeline's overall status.
+
+    COMPLETED if any stage produced output. FAILED only when every applicable
+    stage failed. UNAVAILABLE only when every stage was skipped.
+    """
+    if any(s == AudioAnalysisStatus.COMPLETED for s in statuses):
+        return AudioAnalysisStatus.COMPLETED
+    if any(s == AudioAnalysisStatus.FAILED for s in statuses):
+        return AudioAnalysisStatus.FAILED
+    return AudioAnalysisStatus.UNAVAILABLE
+
+
+def _run_audio_analysis(
+    job_id: str,
+    audio,
+    segments: list[dict],
+    detected_language: str,
+) -> AudioAnalysis:
+    """Run audio analysis stages (SER + prosody). Each stage is best-effort and
+    reports its own status; the rolled-up status reflects whether the pipeline
+    produced any usable output.
+    """
+    segment_models = [TranscriptSegment(**s) for s in segments]
+
+    emotion_status, emotion_reason, emotions = _run_emotion_analysis(
+        job_id, audio, segment_models, detected_language
+    )
+    prosody_status, prosody_reason, prosody, prosody_unavailable = _run_prosody_analysis(
+        job_id, audio, segment_models
+    )
+
+    overall = _roll_up_status(emotion_status, prosody_status)
+    overall_reason: str | None = None
+    if overall != AudioAnalysisStatus.COMPLETED:
+        overall_reason = emotion_reason or prosody_reason
+
+    return AudioAnalysis(
+        status=overall,
+        reason=overall_reason,
+        emotion_status=emotion_status,
+        emotion_reason=emotion_reason,
+        emotions=emotions,
+        prosody_status=prosody_status,
+        prosody_reason=prosody_reason,
+        prosody=prosody,
+        prosody_unavailable=prosody_unavailable,
+    )
 
 
 def _run_transcription(meeting_id: str, job_id: str):

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -112,12 +112,8 @@ def _run_audio_analysis(
     """
     segment_models = [TranscriptSegment(**s) for s in segments]
 
-    emotion_status, emotion_reason, emotions = _run_emotion_analysis(
-        job_id, audio, segment_models, detected_language
-    )
-    prosody_status, prosody_reason, prosody, prosody_unavailable = _run_prosody_analysis(
-        job_id, audio, segment_models
-    )
+    emotion_status, emotion_reason, emotions = _run_emotion_analysis(job_id, audio, segment_models, detected_language)
+    prosody_status, prosody_reason, prosody, prosody_unavailable = _run_prosody_analysis(job_id, audio, segment_models)
 
     overall = _roll_up_status(emotion_status, prosody_status)
     overall_reason: str | None = None

--- a/docs/plans/50-prosodic-feature-extraction.md
+++ b/docs/plans/50-prosodic-feature-extraction.md
@@ -96,4 +96,4 @@ Prosody runs regardless of detected language. Only SER stays English-gated.
 
 ## Deviations from Plan
 
-_Populated after implementation._
+- **Added `too_short` unavailable marker.** QA flagged that sub-`MIN_SEGMENT_SECONDS` segments were silently skipped, violating the truth that every segment must have either prosody data or an explicit unavailable marker. The plan's "skipped silently" behavior was changed to emit a `ProsodyUnavailable` with `reason="too_short"`. Driven by the QA verdict.

--- a/docs/plans/50-prosodic-feature-extraction.md
+++ b/docs/plans/50-prosodic-feature-extraction.md
@@ -1,0 +1,99 @@
+# Plan: Prosodic Feature Extraction
+
+**Story**: #50
+**Spec**: docs/specs/audio-emotional-intelligence.md
+**Branch**: feature/50-prosodic-feature-extraction
+**Date**: 2026-04-28
+**Mode**: Standard — signal processing is hard to TDD-drive without real audio fixtures; tests use synthetic numpy waveforms (sine waves, silence) to validate the math deterministically.
+
+## Technical Decisions
+
+### TD-1: Prosody tool — `praat-parselmouth`
+- **Context**: Story is for sales meeting analysis where pitch accuracy directly impacts hesitation/confidence detection. Initial proposal of `torchaudio.detect_pitch_frequency` (NCCF autocorrelation) is too coarse — it misses voicing decisions, octave errors, and unvoiced frame masking.
+- **Decision**: Use `praat-parselmouth` (Praat via a Python wrapper). Praat's pitch tracker is the de-facto standard in academic speech prosody. Also gives proper intensity (dB SPL) and handles voicing decisions natively.
+- **Alternatives considered**:
+  - `torchaudio.functional.detect_pitch_frequency` — zero new deps but inadequate accuracy for sales-meeting prosody.
+  - `librosa.pyin` — high-quality PYIN pitch but `librosa` pulls a heavier transitive tree (~250MB) and we'd still want intensity from elsewhere.
+  - OpenSMILE — most comprehensive feature set but heavyweight install and a config-file workflow that doesn't match the rest of the codebase.
+
+### TD-2: Per-stage status in `AudioAnalysis`
+- **Context**: Story #49 introduced one rolled-up `status` field on `AudioAnalysis`. Prosody is language-agnostic (BR-2.1) while SER is English-only. With both stages present, a single status can't represent "emotions skipped, prosody completed".
+- **Decision**: Add `emotion_status`/`emotion_reason` and `prosody_status`/`prosody_reason` per-stage fields. Keep the top-level `status` as a roll-up: `COMPLETED` if any stage produced output, `FAILED` only if every applicable stage failed, `UNAVAILABLE` only if every stage was skipped (rare).
+- **Alternatives considered**: Two separate output files (`emotion_analysis.json`, `prosody_analysis.json`). Simpler per stage but breaks the "audio analysis is one feature" mental model and complicates retry.
+
+### TD-3: Volume normalization across the meeting
+- **Context**: AC requires `volume_mean` to be normalized 0–1 within the meeting (BR-2.2). Per-segment dB intensity is comparable across segments but not bounded.
+- **Decision**: Compute raw RMS energy per segment, then divide by the meeting's max RMS in a final pass. `volume_variance` is computed on the same normalized scale so it stays comparable. Pitch is left in Hz (already comparable across speakers, no normalization needed).
+- **Alternatives considered**: Per-speaker baseline calibration (story acknowledges this is an open question). Deferred — meeting-level normalization satisfies the AC and avoids the need for speaker-specific reference passages.
+
+### TD-4: Speaking rate from text + duration
+- **Context**: Speaking rate could come from word-level WhisperX timestamps, but those only exist when alignment ran (`detected_language` is in the supported set). For other languages, we still need a value.
+- **Decision**: Compute WPM as `len(text.split()) / duration_seconds * 60`. Works regardless of alignment. Slight drift from "true" syllable rate but consistent across the meeting.
+- **Alternatives considered**: Word-level timestamps from `result["segments"][i]["words"]` when present. More precise but inconsistent across languages — Thai (one of the project's first-class languages) often loses alignment.
+
+### TD-5: Non-speech detection — RMS floor + voicing ratio
+- **Context**: AC5/BR-2.3 require non-speech segments (silence, music, hold tones) to be excluded.
+- **Decision**: A segment is non-speech when (a) its raw RMS is below `1e-3` AND (b) Praat's pitch tracker yielded zero voiced frames. This catches silence and hold tones reliably; pure music is rare in sales meetings and would still get a `prosody_unavailable` flag if extraction throws.
+- **Alternatives considered**: Run a dedicated VAD (Silero, webrtcvad). Adds another model dependency for marginal benefit at this scope.
+
+## Files to Create or Modify
+
+- `requirements.txt` — add `praat-parselmouth>=0.4.7`.
+- `backend/schemas.py` — add `ProsodyAnnotation`, `ProsodyUnavailable`. Refactor `AudioAnalysis` with per-stage status fields. Add `JobStage.PROSODY_EXTRACTION`.
+- `backend/services/prosody_analyzer.py` *(new)* — `analyze_segments(audio_array, segments) -> tuple[list[ProsodyAnnotation], list[ProsodyUnavailable]]`. Helpers for RMS, pitch (via parselmouth), pause ratio, WPM, non-speech detection. Final pass normalizes volume across the meeting.
+- `backend/services/transcriber.py` — refactor `_run_audio_analysis` to run prosody **always** (when opted in) and SER only for English. Both run best-effort, surfaced via per-stage status.
+- `tests/unit/test_prosody_analyzer.py` *(new)* — synthetic-signal tests for each feature, normalization across segments, non-speech detection, per-segment failure tolerance.
+- `tests/unit/test_schemas.py` — schema validation for new prosody fields.
+- `tests/unit/test_transcriber.py` — update `TestRunAudioAnalysis` for the new pipeline shape.
+
+## Approach per AC
+
+### AC 1 / AC 2: Per-segment prosody annotations with all required fields
+Analyzer returns `ProsodyAnnotation` with `segment_id`, `speaker`, `start`, `end`, `volume_mean` (0–1), `volume_variance`, `pitch_mean` (Hz), `pitch_variance`, `speaking_rate` (WPM), `pause_ratio`.
+
+### AC 3: `segment_id` linkage
+Reuses `TranscriptSegment.id`.
+
+### AC 4: Cross-speaker comparability
+Volume normalized across the meeting (TD-3). Pitch in raw Hz. Speaking rate in absolute WPM. Per-speaker baseline calibration deferred.
+
+### AC 5: Non-speech segments excluded with metadata note
+Non-speech detection per TD-5. Recorded in `prosody_unavailable` with `reason="non_speech"`.
+
+### AC 6: Per-segment failure tolerance
+Try/except per segment. Failures recorded in `prosody_unavailable` with `reason="prosody_unavailable"`. The stage continues.
+
+### AC 7: Skipped when audio analysis opted out
+No new code path. Existing `if metadata.audio_analysis_enabled:` gate covers it.
+
+### AC 8: Persisted alongside emotion annotations
+Same `audio_analysis.json` file; new `prosody` and `prosody_unavailable` arrays under the existing `AudioAnalysis` envelope.
+
+### BR-2.1: Language-agnostic
+Prosody runs regardless of detected language. Only SER stays English-gated.
+
+## Commit Sequence
+
+1. `[#50] Persist implementation plan`
+2. `[#50] Add praat-parselmouth dependency`
+3. `[#50] Add prosody schemas and per-stage audio analysis status`
+4. `[#50] Add prosody analyzer service`
+5. `[#50] Wire prosody extraction into audio analysis pipeline`
+6. `[#50] Add prosody analyzer and pipeline tests`
+
+## Risks and Trade-offs
+
+- **No per-speaker baseline calibration.** Meeting-level normalization satisfies the AC but won't account for individual speakers who naturally speak louder/faster. Tracked as future work.
+- **Speaking rate from text length.** Approximate vs. true syllable rate but consistent and language-agnostic.
+- **Praat is single-threaded.** Slower than a tensor-based extractor on long meetings. Negligible vs. SER cost.
+- **Synthetic test signals only.** Unit tests use sine waves and silence; real-audio behavior validated manually.
+
+## Deviations from Spec
+
+- Spec lists OpenSMILE/Praat/librosa/PyAudioAnalysis as candidates; we use `praat-parselmouth` (TD-1).
+- Spec includes jitter/shimmer in voice quality features; story AC does not require them, so they're omitted from this slice.
+- Spec defines `EnhancedSegment` extending the transcript; we keep transcript untouched and add prosody to the existing sibling `audio_analysis.json` file (continuation of Story #49's storage decision).
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ torchcodec==0.7.0
 noisereduce>=3.0.0
 pyloudnorm>=0.1.1
 soundfile>=0.12.0
+praat-parselmouth>=0.4.7
 
 # Dev dependencies
 pytest>=8.0.0

--- a/tests/unit/test_audio_preprocessor.py
+++ b/tests/unit/test_audio_preprocessor.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import pytest
 
 np = pytest.importorskip("numpy")
+pytest.importorskip("soundfile")
+pytest.importorskip("noisereduce")
+pytest.importorskip("pyloudnorm")
 
 from backend.services.audio_preprocessor import (  # noqa: E402
     HIGHPASS_CUTOFF_HZ,

--- a/tests/unit/test_prosody_analyzer.py
+++ b/tests/unit/test_prosody_analyzer.py
@@ -162,7 +162,6 @@ class TestPerSegmentFailureTolerance:
             _segment("boom", 1.0, 2.0, text="more words now"),
         ]
 
-        original_extract = None
         from backend.services import prosody_analyzer as mod
 
         original_extract = mod._extract_segment_features
@@ -180,6 +179,46 @@ class TestPerSegmentFailureTolerance:
         assert len(unavailable) == 1
         assert unavailable[0].segment_id == "boom"
         assert unavailable[0].reason == REASON_EXTRACTION_FAILED
+
+
+class TestCrossSpeakerComparability:
+    """AC 4 — prosody features are comparable across speakers within a meeting."""
+
+    def test_volume_normalized_consistently_across_speakers(self):
+        # Speaker A loud, Speaker B quiet — the normalized volume should
+        # reflect the actual amplitude difference, not be reset per speaker.
+        loud = _sine(220.0, 1.0, amplitude=0.4)
+        quiet = _sine(180.0, 1.0, amplitude=0.1)
+        audio = np.concatenate([loud, quiet])
+        segments = [
+            _segment("a0", 0.0, 1.0, text="speaker a talking loudly", speaker="SPEAKER_A"),
+            _segment("b0", 1.0, 2.0, text="speaker b talking quietly", speaker="SPEAKER_B"),
+        ]
+        annotations, _ = analyze_segments(audio, segments)
+        by_id = {a.segment_id: a for a in annotations}
+        # Speakers are distinct
+        assert by_id["a0"].speaker == "SPEAKER_A"
+        assert by_id["b0"].speaker == "SPEAKER_B"
+        # Both volumes in 0-1 range (BR-2.2)
+        assert 0.0 <= by_id["a0"].volume_mean <= 1.0
+        assert 0.0 <= by_id["b0"].volume_mean <= 1.0
+        # Normalization captures the actual amplitude ratio across speakers
+        assert by_id["a0"].volume_mean > by_id["b0"].volume_mean
+
+    def test_pitch_in_raw_hz_for_cross_speaker_comparison(self):
+        # Different pitches per speaker — pitch_mean should be in Hz,
+        # not normalized away.
+        speaker_a = _sine(120.0, 1.0)  # lower-pitched
+        speaker_b = _sine(240.0, 1.0)  # higher-pitched
+        audio = np.concatenate([speaker_a, speaker_b])
+        segments = [
+            _segment("a0", 0.0, 1.0, text="speaker a", speaker="SPEAKER_A"),
+            _segment("b0", 1.0, 2.0, text="speaker b", speaker="SPEAKER_B"),
+        ]
+        annotations, _ = analyze_segments(audio, segments)
+        by_id = {a.segment_id: a for a in annotations}
+        assert 110.0 < by_id["a0"].pitch_mean < 130.0
+        assert 230.0 < by_id["b0"].pitch_mean < 250.0
 
 
 class TestShortSegmentsSkipped:

--- a/tests/unit/test_prosody_analyzer.py
+++ b/tests/unit/test_prosody_analyzer.py
@@ -14,6 +14,7 @@ from backend.services.prosody_analyzer import (
     NON_SPEECH_RMS_FLOOR,
     REASON_EXTRACTION_FAILED,
     REASON_NON_SPEECH,
+    REASON_TOO_SHORT,
     SAMPLE_RATE,
     _compute_pause_ratio,
     _compute_rms,
@@ -221,15 +222,19 @@ class TestCrossSpeakerComparability:
         assert 230.0 < by_id["b0"].pitch_mean < 250.0
 
 
-class TestShortSegmentsSkipped:
-    def test_segment_below_min_duration_skipped(self):
+class TestShortSegmentsRecorded:
+    """Truth: every segment must have either a prosody annotation or an
+    explicit unavailable marker. Sub-MIN_SEGMENT_SECONDS segments are too
+    short to analyze, so they get a `too_short` marker."""
+
+    def test_segment_below_min_duration_recorded_as_too_short(self):
         audio = _sine(220.0, 2.0)
         segments = [_segment("tiny", 0.0, 0.1, text="hi")]
         annotations, unavailable = analyze_segments(audio, segments)
-        # Below MIN_SEGMENT_SECONDS the analyzer skips silently — neither
-        # produces an annotation nor an unavailable marker.
         assert annotations == []
-        assert unavailable == []
+        assert len(unavailable) == 1
+        assert unavailable[0].segment_id == "tiny"
+        assert unavailable[0].reason == REASON_TOO_SHORT
 
 
 class TestNonSpeechFloor:

--- a/tests/unit/test_prosody_analyzer.py
+++ b/tests/unit/test_prosody_analyzer.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("parselmouth")
+
+import numpy as np
+
+from backend.schemas import TranscriptSegment
+from backend.services.prosody_analyzer import (
+    NON_SPEECH_RMS_FLOOR,
+    REASON_EXTRACTION_FAILED,
+    REASON_NON_SPEECH,
+    SAMPLE_RATE,
+    _compute_pause_ratio,
+    _compute_rms,
+    _compute_speaking_rate,
+    analyze_segments,
+)
+
+
+def _sine(freq_hz: float, duration_s: float, amplitude: float = 0.3, sr: int = SAMPLE_RATE) -> np.ndarray:
+    t = np.linspace(0, duration_s, int(sr * duration_s), endpoint=False, dtype=np.float64)
+    return (amplitude * np.sin(2 * np.pi * freq_hz * t)).astype(np.float64)
+
+
+def _silence(duration_s: float, sr: int = SAMPLE_RATE) -> np.ndarray:
+    return np.zeros(int(sr * duration_s), dtype=np.float64)
+
+
+def _segment(seg_id: str, start: float, end: float, text: str = "hello there friend", speaker: str = "SPEAKER_00"):
+    return TranscriptSegment(id=seg_id, start=start, end=end, speaker=speaker, text=text)
+
+
+class TestComputeRMS:
+    def test_zero_for_empty(self):
+        assert _compute_rms(np.array([])) == 0.0
+
+    def test_zero_for_silence(self):
+        assert _compute_rms(_silence(1.0)) == 0.0
+
+    def test_matches_known_value_for_sine(self):
+        # RMS of a unit-amplitude sine is 1/sqrt(2) ≈ 0.707
+        sine = _sine(220.0, 1.0, amplitude=1.0)
+        assert _compute_rms(sine) == pytest.approx(1.0 / np.sqrt(2), abs=1e-3)
+
+
+class TestComputeSpeakingRate:
+    def test_basic_wpm(self):
+        # 6 words in 2 seconds → 180 WPM
+        assert _compute_speaking_rate("one two three four five six", 2.0) == 180.0
+
+    def test_zero_duration(self):
+        assert _compute_speaking_rate("hello", 0.0) == 0.0
+
+    def test_empty_text(self):
+        assert _compute_speaking_rate("", 2.0) == 0.0
+
+
+class TestComputePauseRatio:
+    def test_pure_silence_is_one(self):
+        assert _compute_pause_ratio(_silence(1.0), SAMPLE_RATE) == pytest.approx(1.0, abs=1e-6)
+
+    def test_continuous_sine_has_low_pause(self):
+        # A pure tone has near-constant frame RMS, so very few frames fall
+        # below the relative pause threshold.
+        sine = _sine(220.0, 1.0)
+        assert _compute_pause_ratio(sine, SAMPLE_RATE) < 0.1
+
+    def test_half_silence_half_speech(self):
+        # 0.5s of speech, 0.5s of silence → roughly half the frames silent
+        signal = np.concatenate([_sine(220.0, 0.5), _silence(0.5)])
+        ratio = _compute_pause_ratio(signal, SAMPLE_RATE)
+        assert 0.4 < ratio < 0.6
+
+
+class TestAnalyzeSegmentsHappyPath:
+    def test_extracts_pitch_close_to_input_frequency(self):
+        # 2 seconds of 220 Hz sine
+        audio = _sine(220.0, 2.0)
+        segments = [_segment("s0", 0.0, 2.0, text="some words here being spoken aloud")]
+        annotations, unavailable = analyze_segments(audio, segments)
+
+        assert len(annotations) == 1
+        assert unavailable == []
+        ann = annotations[0]
+        # Praat should recover ~220 Hz on a clean sine
+        assert 210.0 < ann.pitch_mean < 230.0
+        assert ann.pitch_variance >= 0.0
+        # Volume normalized 0-1 and reasonable for a single segment
+        assert 0.0 <= ann.volume_mean <= 1.0
+        assert ann.volume_variance >= 0.0
+        # Speaking rate: 6 words / 2s = 180 WPM
+        assert ann.speaking_rate == 180.0
+        # Continuous tone has very low pause ratio
+        assert ann.pause_ratio < 0.2
+
+    def test_segment_id_and_speaker_are_carried_through(self):
+        audio = _sine(180.0, 1.5)
+        segments = [_segment("seg-xyz", 0.0, 1.5, speaker="SPEAKER_07", text="the quick brown fox jumps")]
+        annotations, _ = analyze_segments(audio, segments)
+        assert annotations[0].segment_id == "seg-xyz"
+        assert annotations[0].speaker == "SPEAKER_07"
+        assert annotations[0].start == 0.0
+        assert annotations[0].end == 1.5
+
+
+class TestNonSpeechExclusion:
+    def test_silence_segment_recorded_as_non_speech(self):
+        audio = _silence(2.0)
+        segments = [_segment("silent-0", 0.0, 2.0, text="")]
+        annotations, unavailable = analyze_segments(audio, segments)
+        assert annotations == []
+        assert len(unavailable) == 1
+        assert unavailable[0].segment_id == "silent-0"
+        assert unavailable[0].reason == REASON_NON_SPEECH
+
+    def test_speech_segment_kept_when_silence_segment_excluded(self):
+        # First half: sine speech, second half: silence
+        audio = np.concatenate([_sine(220.0, 1.0), _silence(1.0)])
+        segments = [
+            _segment("s0", 0.0, 1.0, text="alpha bravo charlie delta"),
+            _segment("s1", 1.0, 2.0, text=""),
+        ]
+        annotations, unavailable = analyze_segments(audio, segments)
+        assert len(annotations) == 1
+        assert annotations[0].segment_id == "s0"
+        assert len(unavailable) == 1
+        assert unavailable[0].segment_id == "s1"
+        assert unavailable[0].reason == REASON_NON_SPEECH
+
+
+class TestVolumeNormalization:
+    def test_loud_segment_normalizes_higher_than_quiet_segment(self):
+        # Two segments, one at 4x the amplitude of the other
+        loud = _sine(220.0, 1.0, amplitude=0.4)
+        quiet = _sine(220.0, 1.0, amplitude=0.1)
+        audio = np.concatenate([loud, quiet])
+        segments = [
+            _segment("loud", 0.0, 1.0, text="some loud words being said"),
+            _segment("quiet", 1.0, 2.0, text="some quiet words being said"),
+        ]
+        annotations, _ = analyze_segments(audio, segments)
+        by_id = {a.segment_id: a for a in annotations}
+        assert by_id["loud"].volume_mean > by_id["quiet"].volume_mean
+        assert 0.0 <= by_id["quiet"].volume_mean <= 1.0
+        assert 0.0 <= by_id["loud"].volume_mean <= 1.0
+        # Loudest segment normalizes near (but typically below) 1.0; ratio
+        # should be roughly 4:1 since amplitudes are 4:1
+        ratio = by_id["loud"].volume_mean / by_id["quiet"].volume_mean
+        assert 3.0 < ratio < 5.0
+
+
+class TestPerSegmentFailureTolerance:
+    def test_one_segment_failure_does_not_abort_batch(self):
+        audio = _sine(220.0, 2.0)
+        segments = [
+            _segment("ok", 0.0, 1.0, text="some words here"),
+            _segment("boom", 1.0, 2.0, text="more words now"),
+        ]
+
+        original_extract = None
+        from backend.services import prosody_analyzer as mod
+
+        original_extract = mod._extract_segment_features
+
+        def explode_for_boom(audio_array, segment, sampling_rate):
+            if segment.id == "boom":
+                raise RuntimeError("synthetic failure")
+            return original_extract(audio_array, segment, sampling_rate)
+
+        with patch.object(mod, "_extract_segment_features", side_effect=explode_for_boom):
+            annotations, unavailable = analyze_segments(audio, segments)
+
+        assert len(annotations) == 1
+        assert annotations[0].segment_id == "ok"
+        assert len(unavailable) == 1
+        assert unavailable[0].segment_id == "boom"
+        assert unavailable[0].reason == REASON_EXTRACTION_FAILED
+
+
+class TestShortSegmentsSkipped:
+    def test_segment_below_min_duration_skipped(self):
+        audio = _sine(220.0, 2.0)
+        segments = [_segment("tiny", 0.0, 0.1, text="hi")]
+        annotations, unavailable = analyze_segments(audio, segments)
+        # Below MIN_SEGMENT_SECONDS the analyzer skips silently — neither
+        # produces an annotation nor an unavailable marker.
+        assert annotations == []
+        assert unavailable == []
+
+
+class TestNonSpeechFloor:
+    def test_floor_is_meaningfully_low(self):
+        # Sanity check: the floor needs to admit normal speech RMS levels
+        sine = _sine(220.0, 1.0, amplitude=0.05)
+        assert _compute_rms(sine) > NON_SPEECH_RMS_FLOOR

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -19,6 +19,8 @@ from backend.schemas import (
     MeetingSummary,
     MeetingType,
     MeetingUpdate,
+    ProsodyAnnotation,
+    ProsodyUnavailable,
     SegmentSpeakerUpdate,
     Transcript,
     TranscriptSegment,
@@ -291,3 +293,93 @@ class TestAudioAnalysisFields:
 
     def test_job_stage_emotion_analysis(self):
         assert JobStage.EMOTION_ANALYSIS == "emotion_analysis"
+
+    def test_job_stage_prosody_extraction(self):
+        assert JobStage.PROSODY_EXTRACTION == "prosody_extraction"
+
+
+class TestProsodyAnnotation:
+    def test_creation(self):
+        p = ProsodyAnnotation(
+            segment_id="seg-1",
+            speaker="SPEAKER_00",
+            start=0.0,
+            end=2.5,
+            volume_mean=0.6,
+            volume_variance=0.02,
+            pitch_mean=180.5,
+            pitch_variance=320.4,
+            speaking_rate=145.0,
+            pause_ratio=0.12,
+        )
+        assert p.segment_id == "seg-1"
+        assert p.volume_mean == 0.6
+        assert p.pitch_mean == 180.5
+        assert p.speaking_rate == 145.0
+
+    def test_missing_required_field(self):
+        with pytest.raises(ValidationError):
+            ProsodyAnnotation(
+                segment_id="seg-1",
+                speaker="SPEAKER_00",
+                start=0.0,
+                end=2.5,
+                volume_mean=0.6,
+                volume_variance=0.02,
+                pitch_mean=180.5,
+                pitch_variance=320.4,
+                speaking_rate=145.0,
+            )
+
+
+class TestProsodyUnavailable:
+    def test_creation(self):
+        u = ProsodyUnavailable(segment_id="seg-1", reason="non_speech")
+        assert u.segment_id == "seg-1"
+        assert u.reason == "non_speech"
+
+
+class TestAudioAnalysisProsodyFields:
+    def test_audio_analysis_default_prosody_empty(self):
+        a = AudioAnalysis(status=AudioAnalysisStatus.UNAVAILABLE)
+        assert a.prosody == []
+        assert a.prosody_unavailable == []
+        assert a.prosody_status is None
+        assert a.prosody_reason is None
+        assert a.emotion_status is None
+        assert a.emotion_reason is None
+
+    def test_audio_analysis_with_prosody(self):
+        prosody = [
+            ProsodyAnnotation(
+                segment_id="seg-1",
+                speaker="SPEAKER_00",
+                start=0.0,
+                end=1.0,
+                volume_mean=0.5,
+                volume_variance=0.01,
+                pitch_mean=150.0,
+                pitch_variance=20.0,
+                speaking_rate=120.0,
+                pause_ratio=0.1,
+            )
+        ]
+        a = AudioAnalysis(
+            status=AudioAnalysisStatus.COMPLETED,
+            prosody_status=AudioAnalysisStatus.COMPLETED,
+            prosody=prosody,
+            prosody_unavailable=[ProsodyUnavailable(segment_id="seg-2", reason="non_speech")],
+        )
+        assert len(a.prosody) == 1
+        assert len(a.prosody_unavailable) == 1
+        assert a.prosody_unavailable[0].reason == "non_speech"
+
+    def test_audio_analysis_per_stage_status(self):
+        a = AudioAnalysis(
+            status=AudioAnalysisStatus.COMPLETED,
+            emotion_status=AudioAnalysisStatus.UNAVAILABLE,
+            emotion_reason="language_not_supported:fr",
+            prosody_status=AudioAnalysisStatus.COMPLETED,
+        )
+        assert a.emotion_status == AudioAnalysisStatus.UNAVAILABLE
+        assert a.prosody_status == AudioAnalysisStatus.COMPLETED

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -502,54 +502,107 @@ class TestRunAudioAnalysis:
             {"id": "seg_0000", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_00", "text": "hi"},
         ]
 
-    def test_unsupported_language_returns_unavailable_without_running_model(self):
-        result = _run_audio_analysis(job_id="j1", audio=None, segments=self._segments(), detected_language="fr")
-        assert result.status == AudioAnalysisStatus.UNAVAILABLE
-        assert result.reason == "language_not_supported:fr"
-        assert result.emotions == []
-
-    def test_unknown_language_returns_unavailable(self):
-        result = _run_audio_analysis(job_id="j1", audio=None, segments=self._segments(), detected_language="unknown")
-        assert result.status == AudioAnalysisStatus.UNAVAILABLE
-
-    def test_english_runs_analyzer_and_returns_completed(self):
-        with patch("backend.services.emotion_analyzer.analyze_segments", return_value=[]) as mock_run:
+    def test_unsupported_language_skips_emotion_but_runs_prosody(self):
+        with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])) as mock_prosody:
             with patch("backend.services.transcriber.job_queue.update_job"):
                 result = _run_audio_analysis(
-                    job_id="j1",
-                    audio=MagicMock(),
-                    segments=self._segments(),
-                    detected_language="en",
+                    job_id="j1", audio=MagicMock(), segments=self._segments(), detected_language="fr"
                 )
+        # Emotions skipped (English-only), prosody ran (language-agnostic, BR-2.1)
+        assert result.emotion_status == AudioAnalysisStatus.UNAVAILABLE
+        assert result.emotion_reason == "language_not_supported:fr"
+        assert result.prosody_status == AudioAnalysisStatus.COMPLETED
+        # Pipeline status rolls up — completes when at least one stage produces output
         assert result.status == AudioAnalysisStatus.COMPLETED
-        assert result.emotions == []
-        mock_run.assert_called_once()
+        mock_prosody.assert_called_once()
 
-    def test_analyzer_failure_returns_failed_status_not_raises(self):
+    def test_english_runs_both_stages_and_returns_completed(self):
+        with patch("backend.services.emotion_analyzer.analyze_segments", return_value=[]) as mock_emotion:
+            with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])) as mock_prosody:
+                with patch("backend.services.transcriber.job_queue.update_job"):
+                    result = _run_audio_analysis(
+                        job_id="j1",
+                        audio=MagicMock(),
+                        segments=self._segments(),
+                        detected_language="en",
+                    )
+        assert result.status == AudioAnalysisStatus.COMPLETED
+        assert result.emotion_status == AudioAnalysisStatus.COMPLETED
+        assert result.prosody_status == AudioAnalysisStatus.COMPLETED
+        mock_emotion.assert_called_once()
+        mock_prosody.assert_called_once()
+
+    def test_emotion_failure_does_not_block_prosody(self):
         with patch(
             "backend.services.emotion_analyzer.analyze_segments",
             side_effect=RuntimeError("model crashed"),
         ):
-            with patch("backend.services.transcriber.job_queue.update_job"):
-                result = _run_audio_analysis(
-                    job_id="j1",
-                    audio=MagicMock(),
-                    segments=self._segments(),
-                    detected_language="en",
-                )
-        assert result.status == AudioAnalysisStatus.FAILED
-        assert "model crashed" in result.reason
+            with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])):
+                with patch("backend.services.transcriber.job_queue.update_job"):
+                    result = _run_audio_analysis(
+                        job_id="j1",
+                        audio=MagicMock(),
+                        segments=self._segments(),
+                        detected_language="en",
+                    )
+        # Emotion failed but prosody completed → overall COMPLETED
+        assert result.emotion_status == AudioAnalysisStatus.FAILED
+        assert "model crashed" in result.emotion_reason
+        assert result.prosody_status == AudioAnalysisStatus.COMPLETED
+        assert result.status == AudioAnalysisStatus.COMPLETED
 
-    def test_job_queue_failure_does_not_raise(self):
-        # Defensive: even if update_job blows up, the function must return FAILED, not raise.
+    def test_prosody_failure_does_not_block_emotion(self):
+        with patch("backend.services.emotion_analyzer.analyze_segments", return_value=[]):
+            with patch(
+                "backend.services.prosody_analyzer.analyze_segments",
+                side_effect=RuntimeError("praat crashed"),
+            ):
+                with patch("backend.services.transcriber.job_queue.update_job"):
+                    result = _run_audio_analysis(
+                        job_id="j1",
+                        audio=MagicMock(),
+                        segments=self._segments(),
+                        detected_language="en",
+                    )
+        assert result.prosody_status == AudioAnalysisStatus.FAILED
+        assert "praat crashed" in result.prosody_reason
+        assert result.emotion_status == AudioAnalysisStatus.COMPLETED
+        assert result.status == AudioAnalysisStatus.COMPLETED
+
+    def test_both_stages_fail_rolls_up_to_failed(self):
         with patch(
-            "backend.services.transcriber.job_queue.update_job",
-            side_effect=RuntimeError("queue down"),
+            "backend.services.emotion_analyzer.analyze_segments",
+            side_effect=RuntimeError("emotion boom"),
         ):
-            result = _run_audio_analysis(
-                job_id="j1",
-                audio=MagicMock(),
-                segments=self._segments(),
-                detected_language="en",
-            )
+            with patch(
+                "backend.services.prosody_analyzer.analyze_segments",
+                side_effect=RuntimeError("prosody boom"),
+            ):
+                with patch("backend.services.transcriber.job_queue.update_job"):
+                    result = _run_audio_analysis(
+                        job_id="j1",
+                        audio=MagicMock(),
+                        segments=self._segments(),
+                        detected_language="en",
+                    )
         assert result.status == AudioAnalysisStatus.FAILED
+        assert result.emotion_status == AudioAnalysisStatus.FAILED
+        assert result.prosody_status == AudioAnalysisStatus.FAILED
+
+    def test_prosody_unavailable_markers_propagated(self):
+        from backend.schemas import ProsodyUnavailable
+
+        with patch("backend.services.emotion_analyzer.analyze_segments", return_value=[]):
+            with patch(
+                "backend.services.prosody_analyzer.analyze_segments",
+                return_value=([], [ProsodyUnavailable(segment_id="seg_0000", reason="non_speech")]),
+            ):
+                with patch("backend.services.transcriber.job_queue.update_job"):
+                    result = _run_audio_analysis(
+                        job_id="j1",
+                        audio=MagicMock(),
+                        segments=self._segments(),
+                        detected_language="en",
+                    )
+        assert len(result.prosody_unavailable) == 1
+        assert result.prosody_unavailable[0].reason == "non_speech"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.12"


### PR DESCRIPTION
Closes [#50](https://github.com/nimblehq/audio-transcriber/issues/50)

## Summary

Adds a prosodic feature extraction stage to the audio analysis pipeline. When a meeting is opted in (Story #49), each transcript segment now gets a `ProsodyAnnotation` with `volume_mean` (normalized 0–1 within the meeting), `volume_variance`, `pitch_mean` (Hz), `pitch_variance`, `speaking_rate` (WPM), and `pause_ratio`. Non-speech segments (silence, hold tones) are excluded and noted in `prosody_unavailable` instead.

Prosody runs **regardless of detected language** (BR-2.1) — only SER stays English-gated. Each stage runs best-effort and reports its own status; the rolled-up `AudioAnalysis.status` is `COMPLETED` if any stage produced output.

## Approach

Plan: `docs/plans/50-prosodic-feature-extraction.md`

- **Tool: `praat-parselmouth`** for pitch and intensity. Picked over `torchaudio.detect_pitch_frequency` for accuracy — sales-meeting prosody hinges on subtle hesitation/confidence cues that NCCF autocorrelation misses. Praat handles voicing decisions and octave masking natively.
- **Volume normalization**: per-frame RMS divided by the meeting's peak segment-mean RMS, then mean+variance on the normalized frames. Bounded 0–1 within the meeting and preserves cross-segment ratios.
- **Speaking rate** computed from segment text length and duration so it works regardless of WhisperX alignment availability (Thai etc. lose alignment).
- **Non-speech detection**: RMS below `1e-3` AND zero voiced frames from Praat's pitch tracker. Conjunctive guard avoids false positives.
- **Per-stage status fields** added to `AudioAnalysis` (`emotion_status`, `prosody_status`, plus reasons). Story #49's top-level `status` and `emotions` remain — additive change.
- **Per-segment failure tolerance** (BR-2.4): a try/except around each segment's extraction; failures land in `prosody_unavailable` with reason `"prosody_unavailable"` (matches AC text).

Per-speaker baseline calibration is intentionally deferred — meeting-level normalization satisfies the AC; the spec lists per-speaker calibration as an open engineering question.

## Verification

- All 173 unit + integration + e2e tests pass (`.venv/bin/python -m pytest tests/`)
- New: `tests/unit/test_prosody_analyzer.py` (19 tests) covers RMS, pitch on synthetic sines, pause ratio, WPM, volume normalization across segments, non-speech detection, per-segment failure isolation, and cross-speaker comparability
- Updated `tests/unit/test_transcriber.py::TestRunAudioAnalysis` covers the refactored pipeline: emotions skip + prosody runs for non-English, both stages run for English, per-stage failure isolation, rolled-up status logic, and unavailable-marker propagation
- `tests/unit/test_schemas.py` validates new prosody fields and per-stage status
- `ruff check` passes; `ruff format --check` passes
- Architect review: no Critical or Major issues; minor/nit comments addressed where they tightened AC coverage