### PR TITLE
[#51] Add interaction pattern detection (interruptions, hesitations, dominance)

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -34,6 +34,7 @@ class JobStage(str, Enum):
     DIARIZING = "diarizing"
     EMOTION_ANALYSIS = "emotion_analysis"
     PROSODY_EXTRACTION = "prosody_extraction"
+    INTERACTION_ANALYSIS = "interaction_analysis"
 
 
 class EmotionCategory(str, Enum):
@@ -80,6 +81,29 @@ class ProsodyUnavailable(BaseModel):
     reason: str
 
 
+class InteractionEventType(str, Enum):
+    INTERRUPTION = "interruption"
+    OVERLAP = "overlap"
+    LONG_PAUSE = "long_pause"
+    HESITATION = "hesitation"
+
+
+class InteractionEvent(BaseModel):
+    event_type: InteractionEventType
+    timestamp: float
+    speaker_a: str
+    speaker_b: str
+    duration: float
+    context: str = ""
+
+
+class SegmentInteraction(BaseModel):
+    segment_id: str
+    preceded_by_interruption: bool = False
+    followed_by_interruption: bool = False
+    hesitation_before: float = 0.0
+
+
 class AudioAnalysis(BaseModel):
     status: AudioAnalysisStatus
     reason: str | None = None
@@ -90,6 +114,11 @@ class AudioAnalysis(BaseModel):
     prosody_reason: str | None = None
     prosody: list[ProsodyAnnotation] = Field(default_factory=list)
     prosody_unavailable: list[ProsodyUnavailable] = Field(default_factory=list)
+    interaction_status: AudioAnalysisStatus | None = None
+    interaction_reason: str | None = None
+    interactions: list[InteractionEvent] = Field(default_factory=list)
+    segment_interactions: list[SegmentInteraction] = Field(default_factory=list)
+    dominant_speaker_limitation: bool = False
 
 
 class TranscriptSegment(BaseModel):

--- a/backend/services/interaction_analyzer.py
+++ b/backend/services/interaction_analyzer.py
@@ -84,41 +84,36 @@ def _is_backchannel_text(text: str) -> bool:
     return False
 
 
-def _context_for(timestamp: float, segments: list[_Segment]) -> tuple[str, str | None]:
-    """Return (context text, segment_id) of the transcript segment covering `timestamp`.
+def _segment_at(
+    timestamp: float,
+    segments: list[_Segment],
+    speaker: str | None = None,
+) -> _Segment | None:
+    """Locate the transcript segment containing `timestamp`.
 
-    Falls back to the nearest segment by edge distance when no segment strictly
-    contains the timestamp (gaps between WhisperX segments are common).
+    When `speaker` is given, only segments matching that speaker are considered —
+    important for overlapping turns where multiple transcript segments cover the
+    same timestamp. Falls back to the nearest segment by edge distance when no
+    segment strictly contains the timestamp (gaps between WhisperX segments are
+    common).
     """
     if not segments:
-        return "", None
-    for seg in segments:
-        if seg.start <= timestamp <= seg.end:
-            return seg.text[:CONTEXT_MAX_CHARS], seg.id
-    nearest = min(
-        segments,
-        key=lambda s: min(abs(s.start - timestamp), abs(s.end - timestamp)),
-    )
-    return nearest.text[:CONTEXT_MAX_CHARS], nearest.id
-
-
-def _text_at(timestamp: float, segments: list[_Segment]) -> str:
-    text, _ = _context_for(timestamp, segments)
-    return text
-
-
-def _segment_at(timestamp: float, segments: list[_Segment]) -> _Segment | None:
-    """Locate the transcript segment containing `timestamp`, falling back to the
-    nearest segment if no segment strictly contains it."""
-    if not segments:
         return None
-    for seg in segments:
+    candidates = [s for s in segments if speaker is None or s.speaker == speaker]
+    if not candidates:
+        return None
+    for seg in candidates:
         if seg.start <= timestamp <= seg.end:
             return seg
     return min(
-        segments,
+        candidates,
         key=lambda s: min(abs(s.start - timestamp), abs(s.end - timestamp)),
     )
+
+
+def _text_at(timestamp: float, segments: list[_Segment], speaker: str | None = None) -> str:
+    seg = _segment_at(timestamp, segments, speaker=speaker)
+    return seg.text[:CONTEXT_MAX_CHARS] if seg else ""
 
 
 def _detect_overlaps(
@@ -146,7 +141,7 @@ def _detect_overlaps(
             duration = max(0.0, overlap_end - overlap_start)
 
             duration_b = end_b - start_b
-            text_b = _text_at((start_b + end_b) / 2, transcript_segments)
+            text_b = _text_at((start_b + end_b) / 2, transcript_segments, speaker=spk_b)
             is_backchannel = duration_b <= BACKCHANNEL_MAX_DURATION and _is_backchannel_text(text_b)
 
             event_type = InteractionEventType.OVERLAP if is_backchannel else InteractionEventType.INTERRUPTION
@@ -191,7 +186,7 @@ def _detect_pause_events(
                 speaker_a=prev_spk,
                 speaker_b=curr_spk,
                 duration=round(gap, 2),
-                context=_text_at(curr_start, transcript_segments),
+                context=_text_at(curr_start, transcript_segments, speaker=curr_spk),
             )
         )
 
@@ -224,16 +219,14 @@ def _build_segment_interactions(
     for event in interruption_events:
         if event.event_type != InteractionEventType.INTERRUPTION:
             continue
-        # Interrupter (speaker_b) starts during the interrupted speaker's (a) turn
-        interrupter_seg = _segment_at(event.timestamp, transcript_segments)
-        interrupted_seg = _segment_at(event.timestamp - 1e-3, transcript_segments)
+        # Interrupter (speaker_b) starts during the interrupted speaker's (a) turn.
+        # Speaker-aware lookup matters because both transcript segments cover the
+        # event timestamp during the overlap window.
+        interrupter_seg = _segment_at(event.timestamp, transcript_segments, speaker=event.speaker_b)
+        interrupted_seg = _segment_at(event.timestamp, transcript_segments, speaker=event.speaker_a)
         if interrupter_seg is not None and interrupter_seg.id in annotations:
             annotations[interrupter_seg.id].preceded_by_interruption = True
-        if (
-            interrupted_seg is not None
-            and interrupted_seg.id in annotations
-            and (interrupter_seg is None or interrupted_seg.id != interrupter_seg.id)
-        ):
+        if interrupted_seg is not None and interrupted_seg.id in annotations:
             annotations[interrupted_seg.id].followed_by_interruption = True
 
     return [annotations[seg.id] for seg in transcript_segments]

--- a/backend/services/interaction_analyzer.py
+++ b/backend/services/interaction_analyzer.py
@@ -13,11 +13,18 @@ from backend.schemas import (
 
 logger = logging.getLogger(__name__)
 
-# A segment is a back-channel when it's short AND its text is dominated by
-# acknowledgement tokens. Both conditions are required to avoid false positives
-# on short content words ("Tuesday") and on long agreement statements.
+# A turn is a back-channel when it's short AND its text is dominated by
+# acknowledgement tokens. Both conditions together avoid false positives on
+# short content words ("Tuesday") and on long agreement statements.
+#
+# A duration-only floor catches cases where the lexicon doesn't (production
+# logs surfaced sub-second "Nice." / "Cool." utterances escaping the lexical
+# filter): any utterance ≤ 0.5s with ≤ 2 words is treated as a back-channel
+# regardless of vocabulary.
 BACKCHANNEL_MAX_DURATION = 1.5
 BACKCHANNEL_MAX_WORDS = 3
+BACKCHANNEL_SHORT_DURATION = 0.5
+BACKCHANNEL_SHORT_MAX_WORDS = 2
 BACKCHANNEL_TOKENS = frozenset(
     {
         "uh-huh",
@@ -28,6 +35,9 @@ BACKCHANNEL_TOKENS = frozenset(
         "mmhmm",
         "mhm",
         "mm",
+        "hmm",
+        "oh",
+        "ah",
         "yeah",
         "yep",
         "yup",
@@ -41,6 +51,16 @@ BACKCHANNEL_TOKENS = frozenset(
         "got it",
         "exactly",
         "true",
+        "nice",
+        "cool",
+        "great",
+        "perfect",
+        "awesome",
+        "totally",
+        "indeed",
+        "agreed",
+        "makes sense",
+        "fair enough",
     }
 )
 
@@ -82,6 +102,17 @@ def _is_backchannel_text(text: str) -> bool:
     if len(words) <= BACKCHANNEL_MAX_WORDS and any(w in BACKCHANNEL_TOKENS for w in words):
         return True
     return False
+
+
+def _is_backchannel(duration: float, text: str) -> bool:
+    """Combined back-channel heuristic: duration cap + lexical match, OR a
+    sub-second utterance with at most two words (catches "Nice." / "Cool."
+    that escape the lexicon)."""
+    normalized = _normalize_text(text)
+    word_count = len(normalized.split())
+    if duration <= BACKCHANNEL_SHORT_DURATION and 0 < word_count <= BACKCHANNEL_SHORT_MAX_WORDS:
+        return True
+    return duration <= BACKCHANNEL_MAX_DURATION and _is_backchannel_text(text)
 
 
 def _segment_at(
@@ -142,7 +173,7 @@ def _detect_overlaps(
 
             duration_b = end_b - start_b
             text_b = _text_at((start_b + end_b) / 2, transcript_segments, speaker=spk_b)
-            is_backchannel = duration_b <= BACKCHANNEL_MAX_DURATION and _is_backchannel_text(text_b)
+            is_backchannel = _is_backchannel(duration_b, text_b)
 
             event_type = InteractionEventType.OVERLAP if is_backchannel else InteractionEventType.INTERRUPTION
             events.append(

--- a/backend/services/interaction_analyzer.py
+++ b/backend/services/interaction_analyzer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import bisect
+import heapq
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -124,84 +126,113 @@ def _is_backchannel(duration: float, text: str) -> bool:
     return duration <= BACKCHANNEL_MAX_DURATION and _is_backchannel_text(text)
 
 
-def _segment_at(
-    timestamp: float,
-    segments: list[_Segment],
-    speaker: str | None = None,
-    strict: bool = False,
-) -> _Segment | None:
-    """Locate the transcript segment containing `timestamp`.
+@dataclass
+class _SegmentIndex:
+    """Per-speaker index of transcript segments sorted by start time.
 
-    When `speaker` is given, only segments matching that speaker are considered —
-    important for overlapping turns where multiple transcript segments cover the
-    same timestamp.
-
-    When `strict=False` (default), falls back to the nearest segment by edge
-    distance for context lookups where any nearby text is useful.
-
-    When `strict=True`, returns `None` if no segment strictly contains the
-    timestamp. Used for back-channel decisions, where a far-away segment's text
-    would mis-classify a brief diarization blip that WhisperX didn't transcribe.
+    Built once at the top of `analyze()` so the per-pair text lookups inside
+    `_detect_overlaps` are O(log N) instead of O(N) — the original linear scan
+    + per-call list comprehension was O(M² × N) overall, which made the
+    interaction stage hang at 97% on hour-long meetings.
     """
-    if not segments:
-        return None
-    candidates = [s for s in segments if speaker is None or s.speaker == speaker]
-    if not candidates:
-        return None
-    for seg in candidates:
-        if seg.start <= timestamp <= seg.end:
-            return seg
-    if strict:
-        return None
-    return min(
-        candidates,
-        key=lambda s: min(abs(s.start - timestamp), abs(s.end - timestamp)),
-    )
 
+    by_speaker: dict[str, list[_Segment]]
+    by_speaker_starts: dict[str, list[float]]
+    all_segments: list[_Segment]
+    all_starts: list[float]
 
-def _text_at(
-    timestamp: float,
-    segments: list[_Segment],
-    speaker: str | None = None,
-    strict: bool = False,
-) -> str:
-    seg = _segment_at(timestamp, segments, speaker=speaker, strict=strict)
-    return seg.text[:CONTEXT_MAX_CHARS] if seg else ""
+    @classmethod
+    def build(cls, segments: list[_Segment]) -> _SegmentIndex:
+        by_speaker: dict[str, list[_Segment]] = {}
+        for seg in segments:
+            by_speaker.setdefault(seg.speaker, []).append(seg)
+        for lst in by_speaker.values():
+            lst.sort(key=lambda s: s.start)
+        all_sorted = sorted(segments, key=lambda s: s.start)
+        return cls(
+            by_speaker=by_speaker,
+            by_speaker_starts={spk: [s.start for s in lst] for spk, lst in by_speaker.items()},
+            all_segments=all_sorted,
+            all_starts=[s.start for s in all_sorted],
+        )
+
+    def _lookup_in(self, timestamp: float, segs: list[_Segment], starts: list[float], strict: bool) -> _Segment | None:
+        if not segs:
+            return None
+        # Rightmost segment whose start <= timestamp
+        idx = bisect.bisect_right(starts, timestamp) - 1
+        if 0 <= idx < len(segs) and segs[idx].start <= timestamp <= segs[idx].end:
+            return segs[idx]
+        if strict:
+            return None
+        # Lenient: nearest of the two adjacent candidates by edge distance
+        before = segs[idx] if 0 <= idx < len(segs) else None
+        after = segs[idx + 1] if 0 <= idx + 1 < len(segs) else None
+        if before is None:
+            return after
+        if after is None:
+            return before
+        before_dist = min(abs(before.start - timestamp), abs(before.end - timestamp))
+        after_dist = min(abs(after.start - timestamp), abs(after.end - timestamp))
+        return before if before_dist <= after_dist else after
+
+    def segment_at(self, timestamp: float, speaker: str | None = None, strict: bool = False) -> _Segment | None:
+        if speaker is None:
+            return self._lookup_in(timestamp, self.all_segments, self.all_starts, strict)
+        segs = self.by_speaker.get(speaker, [])
+        starts = self.by_speaker_starts.get(speaker, [])
+        return self._lookup_in(timestamp, segs, starts, strict)
+
+    def text_at(self, timestamp: float, speaker: str | None = None, strict: bool = False) -> str:
+        seg = self.segment_at(timestamp, speaker=speaker, strict=strict)
+        return seg.text[:CONTEXT_MAX_CHARS] if seg else ""
 
 
 def _detect_overlaps(
-    diarize_turns: list[tuple[float, float, str]],
-    transcript_segments: list[_Segment],
+    sorted_turns: list[tuple[float, float, str]],
+    index: _SegmentIndex,
 ) -> list[InteractionEvent]:
-    """Walk diarization turns and emit one event per cross-speaker overlap.
+    """Sweep-line overlap detection.
 
-    Each pair (a, b) where `b` starts before `a` ends and they have different
-    speakers produces either an `interruption` (default) or `overlap` event
-    (when `b` is a back-channel — see TD-2).
+    Maintains a min-heap of currently-active turns (keyed by end time). For each
+    new turn, prunes turns that have already ended, then iterates only the
+    still-active set — turning the worst case from O(M²) into O(M × K) where K
+    is the average overlap density (small for real meetings).
     """
     events: list[InteractionEvent] = []
-    sorted_turns = sorted(diarize_turns, key=lambda t: t[0])
+    # Heap of (end_time, idx) for turns that haven't ended yet
+    active: list[tuple[float, int]] = []
 
     for i, (start_b, end_b, spk_b) in enumerate(sorted_turns):
-        for start_a, end_a, spk_a in sorted_turns[:i]:
+        # Drop turns that ended before this one started
+        while active and active[0][0] <= start_b:
+            heapq.heappop(active)
+
+        midpoint = (start_b + end_b) / 2
+        duration_b = end_b - start_b
+        text_b_strict_cached: str | None = None
+        text_b_lenient_cached: str | None = None
+
+        for _, idx_a in active:
+            start_a, end_a, spk_a = sorted_turns[idx_a]
             if spk_a == spk_b:
                 continue
-            if start_b >= end_a:
-                continue
-            # b starts before a ends → overlap
+            # b started during a's turn (since a is still active)
             overlap_start = max(start_a, start_b)
             overlap_end = min(end_a, end_b)
             duration = max(0.0, overlap_end - overlap_start)
 
-            duration_b = end_b - start_b
-            # Strict lookup for the classification decision — a far-away
-            # transcript segment of speaker B would lie about what was said
-            # during this brief turn.
-            text_b_strict = _text_at((start_b + end_b) / 2, transcript_segments, speaker=spk_b, strict=True)
+            # Lookups depend only on b's turn — same for every active a
+            if text_b_strict_cached is None:
+                text_b_strict_cached = index.text_at(midpoint, speaker=spk_b, strict=True)
+            text_b_strict = text_b_strict_cached
             is_backchannel = _is_backchannel(duration_b, text_b_strict)
-            # Lenient lookup for the stored context so the UI has something
-            # to show even when the strict lookup returned nothing.
-            text_b = text_b_strict or _text_at((start_b + end_b) / 2, transcript_segments, speaker=spk_b)
+            if text_b_strict:
+                text_b = text_b_strict
+            else:
+                if text_b_lenient_cached is None:
+                    text_b_lenient_cached = index.text_at(midpoint, speaker=spk_b)
+                text_b = text_b_lenient_cached
 
             event_type = InteractionEventType.OVERLAP if is_backchannel else InteractionEventType.INTERRUPTION
             events.append(
@@ -215,19 +246,20 @@ def _detect_overlaps(
                 )
             )
 
+        heapq.heappush(active, (end_b, i))
+
     return events
 
 
 def _detect_pause_events(
-    diarize_turns: list[tuple[float, float, str]],
-    transcript_segments: list[_Segment],
+    sorted_turns: list[tuple[float, float, str]],
+    index: _SegmentIndex,
 ) -> list[InteractionEvent]:
     """Emit hesitation/long_pause events for cross-speaker gaps above threshold."""
     events: list[InteractionEvent] = []
-    sorted_turns = sorted(diarize_turns, key=lambda t: t[0])
 
     for prev, curr in zip(sorted_turns, sorted_turns[1:]):
-        prev_start, prev_end, prev_spk = prev
+        _, prev_end, prev_spk = prev
         curr_start, _, curr_spk = curr
         if prev_spk == curr_spk:
             continue
@@ -245,7 +277,7 @@ def _detect_pause_events(
                 speaker_a=prev_spk,
                 speaker_b=curr_spk,
                 duration=round(gap, 2),
-                context=_text_at(curr_start, transcript_segments, speaker=curr_spk),
+                context=index.text_at(curr_start, speaker=curr_spk),
             )
         )
 
@@ -254,26 +286,23 @@ def _detect_pause_events(
 
 def _build_segment_interactions(
     transcript_segments: list[_Segment],
-    diarize_turns: list[tuple[float, float, str]],
+    sorted_turns: list[tuple[float, float, str]],
     interruption_events: list[InteractionEvent],
+    index: _SegmentIndex,
 ) -> list[SegmentInteraction]:
     """Per-segment annotations: hesitation_before + interruption flags."""
-    sorted_turns = sorted(diarize_turns, key=lambda t: t[0])
-
-    # hesitation_before: distance from the most recent prior turn (any speaker).
-    # Using turn timestamps rather than transcript segment edges so the value
-    # reflects the actual silence in the room, not transcript chunking.
     annotations: dict[str, SegmentInteraction] = {
         seg.id: SegmentInteraction(segment_id=seg.id) for seg in transcript_segments
     }
 
+    # hesitation_before: distance from the most recent prior turn (any speaker).
+    # Pre-sort turn ends and use bisect for O(log M) lookup per segment instead
+    # of the original O(M) generator scan that was O(N × M) overall.
+    sorted_ends = sorted(t[1] for t in sorted_turns)
     for seg in transcript_segments:
-        prior_end = max(
-            (t_end for t_start, t_end, _ in sorted_turns if t_end <= seg.start),
-            default=None,
-        )
-        if prior_end is not None:
-            annotations[seg.id].hesitation_before = round(max(0.0, seg.start - prior_end), 2)
+        idx = bisect.bisect_right(sorted_ends, seg.start) - 1
+        if idx >= 0:
+            annotations[seg.id].hesitation_before = round(max(0.0, seg.start - sorted_ends[idx]), 2)
 
     for event in interruption_events:
         if event.event_type != InteractionEventType.INTERRUPTION:
@@ -281,8 +310,8 @@ def _build_segment_interactions(
         # Interrupter (speaker_b) starts during the interrupted speaker's (a) turn.
         # Speaker-aware lookup matters because both transcript segments cover the
         # event timestamp during the overlap window.
-        interrupter_seg = _segment_at(event.timestamp, transcript_segments, speaker=event.speaker_b)
-        interrupted_seg = _segment_at(event.timestamp, transcript_segments, speaker=event.speaker_a)
+        interrupter_seg = index.segment_at(event.timestamp, speaker=event.speaker_b)
+        interrupted_seg = index.segment_at(event.timestamp, speaker=event.speaker_a)
         if interrupter_seg is not None and interrupter_seg.id in annotations:
             annotations[interrupter_seg.id].preceded_by_interruption = True
         if interrupted_seg is not None and interrupted_seg.id in annotations:
@@ -317,13 +346,14 @@ def analyze(
     per-segment annotation output.
     """
     segments = list(transcript_segments)
-    turns = list(diarize_turns)
+    sorted_turns = sorted(diarize_turns, key=lambda t: t[0])
+    index = _SegmentIndex.build(segments)
 
-    overlap_events = _detect_overlaps(turns, segments)
-    pause_events = _detect_pause_events(turns, segments)
+    overlap_events = _detect_overlaps(sorted_turns, index)
+    pause_events = _detect_pause_events(sorted_turns, index)
     events = sorted(overlap_events + pause_events, key=lambda e: e.timestamp)
 
-    segment_interactions = _build_segment_interactions(segments, turns, overlap_events)
+    segment_interactions = _build_segment_interactions(segments, sorted_turns, overlap_events, index)
     dominant = _check_dominance(segments)
 
     return InteractionAnalysisResult(

--- a/backend/services/interaction_analyzer.py
+++ b/backend/services/interaction_analyzer.py
@@ -105,13 +105,22 @@ def _is_backchannel_text(text: str) -> bool:
 
 
 def _is_backchannel(duration: float, text: str) -> bool:
-    """Combined back-channel heuristic: duration cap + lexical match, OR a
-    sub-second utterance with at most two words (catches "Nice." / "Cool."
-    that escape the lexicon)."""
+    """Combined back-channel heuristic. A turn is a back-channel when:
+
+    - it's sub-floor (≤ 0.5s) AND has no transcript text (PyAnnote split a
+      brief vocalization that WhisperX didn't deem worth transcribing — this
+      is the dominant pattern for false-positive interruptions in real audio), OR
+    - it's sub-floor with at most two words (catches "Nice." / "Cool." that
+      escape the lexicon), OR
+    - it's within the duration cap and lexically matches an acknowledgement.
+    """
     normalized = _normalize_text(text)
     word_count = len(normalized.split())
-    if duration <= BACKCHANNEL_SHORT_DURATION and 0 < word_count <= BACKCHANNEL_SHORT_MAX_WORDS:
-        return True
+    if duration <= BACKCHANNEL_SHORT_DURATION:
+        if word_count == 0:
+            return True
+        if word_count <= BACKCHANNEL_SHORT_MAX_WORDS:
+            return True
     return duration <= BACKCHANNEL_MAX_DURATION and _is_backchannel_text(text)
 
 
@@ -119,14 +128,20 @@ def _segment_at(
     timestamp: float,
     segments: list[_Segment],
     speaker: str | None = None,
+    strict: bool = False,
 ) -> _Segment | None:
     """Locate the transcript segment containing `timestamp`.
 
     When `speaker` is given, only segments matching that speaker are considered —
     important for overlapping turns where multiple transcript segments cover the
-    same timestamp. Falls back to the nearest segment by edge distance when no
-    segment strictly contains the timestamp (gaps between WhisperX segments are
-    common).
+    same timestamp.
+
+    When `strict=False` (default), falls back to the nearest segment by edge
+    distance for context lookups where any nearby text is useful.
+
+    When `strict=True`, returns `None` if no segment strictly contains the
+    timestamp. Used for back-channel decisions, where a far-away segment's text
+    would mis-classify a brief diarization blip that WhisperX didn't transcribe.
     """
     if not segments:
         return None
@@ -136,14 +151,21 @@ def _segment_at(
     for seg in candidates:
         if seg.start <= timestamp <= seg.end:
             return seg
+    if strict:
+        return None
     return min(
         candidates,
         key=lambda s: min(abs(s.start - timestamp), abs(s.end - timestamp)),
     )
 
 
-def _text_at(timestamp: float, segments: list[_Segment], speaker: str | None = None) -> str:
-    seg = _segment_at(timestamp, segments, speaker=speaker)
+def _text_at(
+    timestamp: float,
+    segments: list[_Segment],
+    speaker: str | None = None,
+    strict: bool = False,
+) -> str:
+    seg = _segment_at(timestamp, segments, speaker=speaker, strict=strict)
     return seg.text[:CONTEXT_MAX_CHARS] if seg else ""
 
 
@@ -172,8 +194,14 @@ def _detect_overlaps(
             duration = max(0.0, overlap_end - overlap_start)
 
             duration_b = end_b - start_b
-            text_b = _text_at((start_b + end_b) / 2, transcript_segments, speaker=spk_b)
-            is_backchannel = _is_backchannel(duration_b, text_b)
+            # Strict lookup for the classification decision — a far-away
+            # transcript segment of speaker B would lie about what was said
+            # during this brief turn.
+            text_b_strict = _text_at((start_b + end_b) / 2, transcript_segments, speaker=spk_b, strict=True)
+            is_backchannel = _is_backchannel(duration_b, text_b_strict)
+            # Lenient lookup for the stored context so the UI has something
+            # to show even when the strict lookup returned nothing.
+            text_b = text_b_strict or _text_at((start_b + end_b) / 2, transcript_segments, speaker=spk_b)
 
             event_type = InteractionEventType.OVERLAP if is_backchannel else InteractionEventType.INTERRUPTION
             events.append(

--- a/backend/services/interaction_analyzer.py
+++ b/backend/services/interaction_analyzer.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from backend.schemas import (
+    InteractionEvent,
+    InteractionEventType,
+    SegmentInteraction,
+)
+
+logger = logging.getLogger(__name__)
+
+# A segment is a back-channel when it's short AND its text is dominated by
+# acknowledgement tokens. Both conditions are required to avoid false positives
+# on short content words ("Tuesday") and on long agreement statements.
+BACKCHANNEL_MAX_DURATION = 1.5
+BACKCHANNEL_MAX_WORDS = 3
+BACKCHANNEL_TOKENS = frozenset(
+    {
+        "uh-huh",
+        "uhhuh",
+        "uh",
+        "huh",
+        "mm-hmm",
+        "mmhmm",
+        "mhm",
+        "mm",
+        "yeah",
+        "yep",
+        "yup",
+        "yes",
+        "ok",
+        "okay",
+        "right",
+        "sure",
+        "wow",
+        "i see",
+        "got it",
+        "exactly",
+        "true",
+    }
+)
+
+HESITATION_MIN_SECONDS = 0.7
+LONG_PAUSE_MIN_SECONDS = 3.0
+
+DOMINANT_SPEAKER_THRESHOLD = 0.8
+
+CONTEXT_MAX_CHARS = 120
+
+
+class _Segment(Protocol):
+    id: str
+    start: float
+    end: float
+    speaker: str
+    text: str
+
+
+@dataclass
+class InteractionAnalysisResult:
+    events: list[InteractionEvent] = field(default_factory=list)
+    segment_interactions: list[SegmentInteraction] = field(default_factory=list)
+    dominant_speaker_limitation: bool = False
+
+
+def _normalize_text(text: str) -> str:
+    return text.lower().strip().strip(".,!?-").strip()
+
+
+def _is_backchannel_text(text: str) -> bool:
+    """Lexical half of the back-channel heuristic."""
+    normalized = _normalize_text(text)
+    if not normalized:
+        return False
+    if normalized in BACKCHANNEL_TOKENS:
+        return True
+    words = normalized.split()
+    if len(words) <= BACKCHANNEL_MAX_WORDS and any(w in BACKCHANNEL_TOKENS for w in words):
+        return True
+    return False
+
+
+def _context_for(timestamp: float, segments: list[_Segment]) -> tuple[str, str | None]:
+    """Return (context text, segment_id) of the transcript segment covering `timestamp`.
+
+    Falls back to the nearest segment by edge distance when no segment strictly
+    contains the timestamp (gaps between WhisperX segments are common).
+    """
+    if not segments:
+        return "", None
+    for seg in segments:
+        if seg.start <= timestamp <= seg.end:
+            return seg.text[:CONTEXT_MAX_CHARS], seg.id
+    nearest = min(
+        segments,
+        key=lambda s: min(abs(s.start - timestamp), abs(s.end - timestamp)),
+    )
+    return nearest.text[:CONTEXT_MAX_CHARS], nearest.id
+
+
+def _text_at(timestamp: float, segments: list[_Segment]) -> str:
+    text, _ = _context_for(timestamp, segments)
+    return text
+
+
+def _segment_at(timestamp: float, segments: list[_Segment]) -> _Segment | None:
+    """Locate the transcript segment containing `timestamp`, falling back to the
+    nearest segment if no segment strictly contains it."""
+    if not segments:
+        return None
+    for seg in segments:
+        if seg.start <= timestamp <= seg.end:
+            return seg
+    return min(
+        segments,
+        key=lambda s: min(abs(s.start - timestamp), abs(s.end - timestamp)),
+    )
+
+
+def _detect_overlaps(
+    diarize_turns: list[tuple[float, float, str]],
+    transcript_segments: list[_Segment],
+) -> list[InteractionEvent]:
+    """Walk diarization turns and emit one event per cross-speaker overlap.
+
+    Each pair (a, b) where `b` starts before `a` ends and they have different
+    speakers produces either an `interruption` (default) or `overlap` event
+    (when `b` is a back-channel — see TD-2).
+    """
+    events: list[InteractionEvent] = []
+    sorted_turns = sorted(diarize_turns, key=lambda t: t[0])
+
+    for i, (start_b, end_b, spk_b) in enumerate(sorted_turns):
+        for start_a, end_a, spk_a in sorted_turns[:i]:
+            if spk_a == spk_b:
+                continue
+            if start_b >= end_a:
+                continue
+            # b starts before a ends → overlap
+            overlap_start = max(start_a, start_b)
+            overlap_end = min(end_a, end_b)
+            duration = max(0.0, overlap_end - overlap_start)
+
+            duration_b = end_b - start_b
+            text_b = _text_at((start_b + end_b) / 2, transcript_segments)
+            is_backchannel = duration_b <= BACKCHANNEL_MAX_DURATION and _is_backchannel_text(text_b)
+
+            event_type = InteractionEventType.OVERLAP if is_backchannel else InteractionEventType.INTERRUPTION
+            events.append(
+                InteractionEvent(
+                    event_type=event_type,
+                    timestamp=round(start_b, 2),
+                    speaker_a=spk_a,
+                    speaker_b=spk_b,
+                    duration=round(duration, 2),
+                    context=text_b,
+                )
+            )
+
+    return events
+
+
+def _detect_pause_events(
+    diarize_turns: list[tuple[float, float, str]],
+    transcript_segments: list[_Segment],
+) -> list[InteractionEvent]:
+    """Emit hesitation/long_pause events for cross-speaker gaps above threshold."""
+    events: list[InteractionEvent] = []
+    sorted_turns = sorted(diarize_turns, key=lambda t: t[0])
+
+    for prev, curr in zip(sorted_turns, sorted_turns[1:]):
+        prev_start, prev_end, prev_spk = prev
+        curr_start, _, curr_spk = curr
+        if prev_spk == curr_spk:
+            continue
+        gap = curr_start - prev_end
+        if gap < HESITATION_MIN_SECONDS:
+            continue
+
+        event_type = (
+            InteractionEventType.LONG_PAUSE if gap >= LONG_PAUSE_MIN_SECONDS else InteractionEventType.HESITATION
+        )
+        events.append(
+            InteractionEvent(
+                event_type=event_type,
+                timestamp=round(prev_end, 2),
+                speaker_a=prev_spk,
+                speaker_b=curr_spk,
+                duration=round(gap, 2),
+                context=_text_at(curr_start, transcript_segments),
+            )
+        )
+
+    return events
+
+
+def _build_segment_interactions(
+    transcript_segments: list[_Segment],
+    diarize_turns: list[tuple[float, float, str]],
+    interruption_events: list[InteractionEvent],
+) -> list[SegmentInteraction]:
+    """Per-segment annotations: hesitation_before + interruption flags."""
+    sorted_turns = sorted(diarize_turns, key=lambda t: t[0])
+
+    # hesitation_before: distance from the most recent prior turn (any speaker).
+    # Using turn timestamps rather than transcript segment edges so the value
+    # reflects the actual silence in the room, not transcript chunking.
+    annotations: dict[str, SegmentInteraction] = {
+        seg.id: SegmentInteraction(segment_id=seg.id) for seg in transcript_segments
+    }
+
+    for seg in transcript_segments:
+        prior_end = max(
+            (t_end for t_start, t_end, _ in sorted_turns if t_end <= seg.start),
+            default=None,
+        )
+        if prior_end is not None:
+            annotations[seg.id].hesitation_before = round(max(0.0, seg.start - prior_end), 2)
+
+    for event in interruption_events:
+        if event.event_type != InteractionEventType.INTERRUPTION:
+            continue
+        # Interrupter (speaker_b) starts during the interrupted speaker's (a) turn
+        interrupter_seg = _segment_at(event.timestamp, transcript_segments)
+        interrupted_seg = _segment_at(event.timestamp - 1e-3, transcript_segments)
+        if interrupter_seg is not None and interrupter_seg.id in annotations:
+            annotations[interrupter_seg.id].preceded_by_interruption = True
+        if (
+            interrupted_seg is not None
+            and interrupted_seg.id in annotations
+            and (interrupter_seg is None or interrupted_seg.id != interrupter_seg.id)
+        ):
+            annotations[interrupted_seg.id].followed_by_interruption = True
+
+    return [annotations[seg.id] for seg in transcript_segments]
+
+
+def _check_dominance(transcript_segments: list[_Segment]) -> bool:
+    """True when one speaker accounts for more than 80% of total speaking time."""
+    totals: dict[str, float] = {}
+    grand_total = 0.0
+    for seg in transcript_segments:
+        duration = max(0.0, seg.end - seg.start)
+        totals[seg.speaker] = totals.get(seg.speaker, 0.0) + duration
+        grand_total += duration
+    if grand_total <= 0.0:
+        return False
+    return max(totals.values()) / grand_total > DOMINANT_SPEAKER_THRESHOLD
+
+
+def analyze(
+    transcript_segments: Iterable[_Segment],
+    diarize_turns: Iterable[tuple[float, float, str]],
+) -> InteractionAnalysisResult:
+    """Detect interaction patterns from PyAnnote diarization turns.
+
+    `diarize_turns` are the raw, possibly-overlapping speaker turns from
+    PyAnnote (after WhisperX collapses them via `assign_word_speakers`, the
+    overlap data is gone — so this function expects the raw form). Transcript
+    segments are used for context strings, back-channel text lookup, and the
+    per-segment annotation output.
+    """
+    segments = list(transcript_segments)
+    turns = list(diarize_turns)
+
+    overlap_events = _detect_overlaps(turns, segments)
+    pause_events = _detect_pause_events(turns, segments)
+    events = sorted(overlap_events + pause_events, key=lambda e: e.timestamp)
+
+    segment_interactions = _build_segment_interactions(segments, turns, overlap_events)
+    dominant = _check_dominance(segments)
+
+    return InteractionAnalysisResult(
+        events=events,
+        segment_interactions=segment_interactions,
+        dominant_speaker_limitation=dominant,
+    )

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -87,6 +87,38 @@ def _run_prosody_analysis(
         return AudioAnalysisStatus.FAILED, str(e), [], []
 
 
+def _run_interaction_analysis(
+    job_id: str,
+    segment_models: list[TranscriptSegment],
+    diarize_turns: list[tuple[float, float, str]] | None,
+) -> tuple[AudioAnalysisStatus, str | None, list, list, bool]:
+    """Run interaction pattern detection (language-agnostic).
+
+    Returns (status, reason, events, segment_interactions, dominant_speaker_limitation).
+    Without raw PyAnnote turns (no diarization), the stage is unavailable.
+    """
+    if not diarize_turns:
+        logger.info("Skipping interaction analysis: no diarization turns available")
+        return AudioAnalysisStatus.UNAVAILABLE, "diarization_unavailable", [], [], False
+
+    try:
+        job_queue.update_job(job_id, stage="interaction_analysis", progress=97)
+
+        from backend.services.interaction_analyzer import analyze as analyze_interactions
+
+        result = analyze_interactions(transcript_segments=segment_models, diarize_turns=diarize_turns)
+        return (
+            AudioAnalysisStatus.COMPLETED,
+            None,
+            result.events,
+            result.segment_interactions,
+            result.dominant_speaker_limitation,
+        )
+    except Exception as e:
+        logger.exception("Interaction analysis failed")
+        return AudioAnalysisStatus.FAILED, str(e), [], [], False
+
+
 def _roll_up_status(*statuses: AudioAnalysisStatus) -> AudioAnalysisStatus:
     """Combine per-stage statuses into the pipeline's overall status.
 
@@ -105,20 +137,28 @@ def _run_audio_analysis(
     audio,
     segments: list[dict],
     detected_language: str,
+    diarize_turns: list[tuple[float, float, str]] | None = None,
 ) -> AudioAnalysis:
-    """Run audio analysis stages (SER + prosody). Each stage is best-effort and
-    reports its own status; the rolled-up status reflects whether the pipeline
-    produced any usable output.
+    """Run audio analysis stages (SER + prosody + interactions). Each stage is
+    best-effort and reports its own status; the rolled-up status reflects
+    whether the pipeline produced any usable output.
     """
     segment_models = [TranscriptSegment(**s) for s in segments]
 
     emotion_status, emotion_reason, emotions = _run_emotion_analysis(job_id, audio, segment_models, detected_language)
     prosody_status, prosody_reason, prosody, prosody_unavailable = _run_prosody_analysis(job_id, audio, segment_models)
+    (
+        interaction_status,
+        interaction_reason,
+        interactions,
+        segment_interactions,
+        dominant_speaker_limitation,
+    ) = _run_interaction_analysis(job_id, segment_models, diarize_turns)
 
-    overall = _roll_up_status(emotion_status, prosody_status)
+    overall = _roll_up_status(emotion_status, prosody_status, interaction_status)
     overall_reason: str | None = None
     if overall != AudioAnalysisStatus.COMPLETED:
-        overall_reason = emotion_reason or prosody_reason
+        overall_reason = emotion_reason or prosody_reason or interaction_reason
 
     return AudioAnalysis(
         status=overall,
@@ -130,6 +170,11 @@ def _run_audio_analysis(
         prosody_reason=prosody_reason,
         prosody=prosody,
         prosody_unavailable=prosody_unavailable,
+        interaction_status=interaction_status,
+        interaction_reason=interaction_reason,
+        interactions=interactions,
+        segment_interactions=segment_interactions,
+        dominant_speaker_limitation=dominant_speaker_limitation,
     )
 
 
@@ -285,6 +330,7 @@ def _run_transcription(meeting_id: str, job_id: str):
                 torch.cuda.empty_cache()
 
         # Diarize
+        diarize_turns: list[tuple[float, float, str]] | None = None
         if HF_TOKEN:
             job_queue.update_job(job_id, stage="diarizing", progress=70)
             diarize_model = DiarizationPipeline(
@@ -296,6 +342,17 @@ def _run_transcription(meeting_id: str, job_id: str):
             if metadata.num_speakers:
                 diarize_kwargs["num_speakers"] = metadata.num_speakers
             diarize_segments = diarize_model(audio, **diarize_kwargs)
+            # Capture raw PyAnnote turns (with overlaps) before assign_word_speakers
+            # collapses them into per-speaker non-overlapping transcript segments.
+            # Required by interaction analysis (BR-3.1).
+            try:
+                diarize_turns = [
+                    (float(row["start"]), float(row["end"]), str(row["speaker"]))
+                    for _, row in diarize_segments.iterrows()
+                ]
+            except Exception:
+                logger.exception("Failed to capture raw diarization turns; interaction analysis will be unavailable")
+                diarize_turns = None
             result = assign_word_speakers(diarize_segments, result)
 
         job_queue.update_job(job_id, progress=90, stage="saving")
@@ -322,7 +379,9 @@ def _run_transcription(meeting_id: str, job_id: str):
         audio_analysis: AudioAnalysis | None = None
         if metadata.audio_analysis_enabled:
             try:
-                audio_analysis = _run_audio_analysis(job_id, audio, segments, detected_language)
+                audio_analysis = _run_audio_analysis(
+                    job_id, audio, segments, detected_language, diarize_turns=diarize_turns
+                )
             except Exception as e:
                 logger.exception("Audio analysis raised unexpectedly; continuing with meeting")
                 audio_analysis = AudioAnalysis(status=AudioAnalysisStatus.FAILED, reason=str(e))

--- a/docs/plans/51-interaction-pattern-detection.md
+++ b/docs/plans/51-interaction-pattern-detection.md
@@ -1,0 +1,91 @@
+# Plan: Interaction Pattern Detection
+
+**Story**: #51
+**Spec**: docs/specs/audio-emotional-intelligence.md
+**Branch**: feature/51-interaction-pattern-detection
+**Date**: 2026-04-29
+**Mode**: Standard — pure-logic analysis on segment timestamps; tests use synthetic segment fixtures, no audio fixtures needed.
+
+## Technical Decisions
+
+### TD-1: Use raw PyAnnote `diarize_segments` for true overlap detection
+- **Context**: WhisperX's `assign_word_speakers` collapses output into non-overlapping per-speaker segments; true overlap data only lives in PyAnnote's raw output. BR-3.1 requires detecting "Speaker B starts before Speaker A finishes their turn" — a real overlap.
+- **Decision**: In the transcriber, normalize the diarization DataFrame into a plain `list[tuple[float, float, str]]` (start, end, speaker) and pass it to the interaction analyzer alongside transcript segments. Without diarization (no `HF_TOKEN`), the interaction stage marks `UNAVAILABLE`.
+- **Alternatives considered**: Detect interruption from adjacent transcript segments where gap < 0. Misses most real overlaps because the transcript stream is serialized.
+
+### TD-2: Back-channel heuristic — duration + lexical filter
+- **Context**: Story leaves the heuristic to engineering and warns it must not inflate the interruption count.
+- **Decision**: A diarization turn is a back-channel when its duration ≤ 1.5s AND its corresponding transcript text matches a curated set of acknowledgement tokens (`uh-huh`, `mm-hmm`, `yeah`, `right`, `ok`, `sure`, `i see`, etc.) — either as the whole utterance or, for ≤3-word utterances, as one of the words. Transcript text is looked up from the transcript segment overlapping the turn's midpoint.
+- **Alternatives considered**: Pure duration filter (false positives on short content like "Tuesday"); lexical-only (false positives on long agreement statements).
+
+### TD-3: Pause thresholds
+- **Context**: Story leaves the threshold to engineering; AC requires capturing duration before each turn.
+- **Decision**: `HESITATION_MIN_SECONDS = 0.7`, `LONG_PAUSE_MIN_SECONDS = 3.0`. A `hesitation` event fires when `0.7 ≤ gap < 3.0`; a `long_pause` event fires when `gap ≥ 3.0`. `hesitation_before` on each segment always carries the gap from the prior speaker's end (clamped ≥ 0), independent of whether a hesitation event was emitted.
+- **Alternatives considered**: Speaker-relative thresholds (per-speaker baseline). Out of scope; deferred.
+
+### TD-4: Segment annotations stored as a sibling list, not on transcript
+- **Context**: Spec's `EnhancedSegment` shows the booleans/hesitation_before as transcript fields. Story #49/#50 decided to keep transcript schema untouched and put audio analysis in a sibling file.
+- **Decision**: Add `segment_interactions: list[SegmentInteraction]` inside `AudioAnalysis`, keyed by `segment_id`, carrying `preceded_by_interruption`, `followed_by_interruption`, `hesitation_before`. Frontend joins by segment ID when needed.
+
+### TD-5: Dominance flag on `AudioAnalysis`
+- **Context**: AC says "records a `dominant_speaker_limitation` flag in metadata". The audio_analysis.json envelope is the audio analysis metadata.
+- **Decision**: `dominant_speaker_limitation: bool = False` lives on `AudioAnalysis`. Computed from total speaking duration per speaker on the transcript segments — > 80% triggers the flag. Stage still completes successfully (BR-3.4).
+
+## Files to Create or Modify
+
+- `backend/schemas.py` — add `InteractionEventType` enum, `InteractionEvent`, `SegmentInteraction` models. Extend `AudioAnalysis` with interaction fields and `dominant_speaker_limitation`. Add `JobStage.INTERACTION_ANALYSIS`.
+- `backend/services/interaction_analyzer.py` *(new)* — `analyze(transcript_segments, diarize_turns) -> InteractionAnalysisResult`. Helpers for back-channel detection, overlap classification, pause/hesitation events, segment annotation builder, dominance check.
+- `backend/services/transcriber.py` — capture `diarize_segments` as a normalized list, add `_run_interaction_analysis`, wire into `_run_audio_analysis`, update roll-up to include the new stage.
+- `tests/unit/test_interaction_analyzer.py` *(new)* — synthetic-segment tests for back-channel filtering, interruption vs overlap, hesitation/long-pause events, segment annotations, dominance flag.
+- `tests/unit/test_schemas.py` — schema validation for new interaction fields.
+- `tests/unit/test_transcriber.py` — extend `TestRunAudioAnalysis` for the three-stage pipeline.
+
+## Approach per AC
+
+### AC 1: Interaction stage produces events when audio analysis is opted in
+`_run_interaction_analysis` invoked when `audio_analysis_enabled` and diarize_turns are present. Produces an `interactions` list on `AudioAnalysis`.
+
+### AC 2: Each event has all required fields
+`InteractionEvent { event_type, timestamp, speaker_a, speaker_b, duration, context }`. Context taken from transcript segment overlapping the event timestamp (truncated to ~120 chars).
+
+### AC 3: Interruptions ≠ back-channels
+Back-channel heuristic (TD-2) classifies the overlapping turn as an `overlap` event rather than `interruption`. Non-back-channel overlaps emit `interruption`.
+
+### AC 4: Hesitation before each turn captured per segment
+For every segment, `hesitation_before` = max(0, segment.start − prior_turn.end). Stored in `SegmentInteraction`. A `hesitation` event is emitted when the gap falls in the threshold band.
+
+### AC 5: Single-speaker dominance still completes
+Compute speaker shares from transcript segment durations; if `max_share > 0.8`, set `dominant_speaker_limitation = True`. Stage continues.
+
+### AC 6: Per-segment interruption booleans
+For each `interruption` event, mark `preceded_by_interruption = True` on the segment containing the interrupter's start, and `followed_by_interruption = True` on the segment containing the prior turn's overlap point. Builder iterates events once.
+
+### AC 7: Skipped when opted out
+No new code path — existing `if metadata.audio_analysis_enabled:` gate covers it.
+
+### AC 8: No new model inference
+Pure timestamp arithmetic + lexical lookup; no new dependencies.
+
+## Commit Sequence
+
+1. `[#51] Persist implementation plan`
+2. `[#51] Add interaction event schemas and audio analysis fields`
+3. `[#51] Add interaction analyzer service`
+4. `[#51] Wire interaction analysis into transcription pipeline`
+5. `[#51] Add interaction analyzer and pipeline tests`
+
+## Risks and Trade-offs
+
+- **Back-channel lexical list is English-biased.** Multilingual back-channel detection (Thai, French) is out of scope for this slice — non-English interjections may be misclassified as interruptions. Documented as a known limitation.
+- **Context strings are truncated and may straddle turn boundaries.** Acceptable for AC; UI can re-derive richer context from the transcript using the timestamp.
+- **No raw PyAnnote → no interactions.** Without `HF_TOKEN`, interaction stage marks `UNAVAILABLE`. Same convention as prosody/emotion when prerequisites are missing.
+- **Threshold values are engineering judgments.** 0.7s hesitation / 3.0s long_pause / 1.5s back-channel-max / 0.8 dominance ratio — all tunable via constants.
+
+## Deviations from Spec
+
+- Spec's `EnhancedSegment` extends transcript with the interaction booleans; we keep transcript untouched and add `segment_interactions` to `AudioAnalysis` (continuation of storage decision from #49/#50).
+- Spec lists "back-channel" as a detection category; we use it only as a *filter* on overlaps since the AC's `event_type` set is `{interruption, overlap, long_pause, hesitation}`.
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -26,6 +26,7 @@ async function loadMeetingView(container, meetingId) {
                     <h1 id="meeting-title">${escapeHtml(meta.title)}</h1>
                     <div class="header-actions">
                         <span class="badge badge-${meta.type}">${meta.type}</span>
+                        ${!isProcessing ? `<button class="btn btn-text" onclick="handleRerunTranscription('${meetingId}')">Re-run</button>` : ''}
                         <button class="btn btn-text btn-delete" onclick="handleDeleteMeeting('${meetingId}')">Delete</button>
                     </div>
                 </div>
@@ -523,6 +524,11 @@ async function retryTranscription(meetingId) {
     } catch (err) {
         showToast(err.message, 'error');
     }
+}
+
+async function handleRerunTranscription(meetingId) {
+    if (!confirm('Re-run transcription? The existing transcript and analysis will be overwritten.')) return;
+    await retryTranscription(meetingId);
 }
 
 async function handleCancelTranscription(meetingId) {

--- a/tests/unit/test_interaction_analyzer.py
+++ b/tests/unit/test_interaction_analyzer.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from backend.schemas import InteractionEventType, TranscriptSegment
+from backend.services.interaction_analyzer import (
+    BACKCHANNEL_MAX_DURATION,
+    DOMINANT_SPEAKER_THRESHOLD,
+    HESITATION_MIN_SECONDS,
+    LONG_PAUSE_MIN_SECONDS,
+    _is_backchannel_text,
+    analyze,
+)
+
+
+def _seg(
+    seg_id: str, start: float, end: float, speaker: str = "SPEAKER_00", text: str = "hello world"
+) -> TranscriptSegment:
+    return TranscriptSegment(id=seg_id, start=start, end=end, speaker=speaker, text=text)
+
+
+class TestBackchannelTextHeuristic:
+    def test_pure_acknowledgement_is_backchannel(self):
+        assert _is_backchannel_text("yeah") is True
+        assert _is_backchannel_text("Mm-hmm") is True
+        assert _is_backchannel_text("uh-huh.") is True
+        assert _is_backchannel_text("right!") is True
+
+    def test_short_phrase_with_acknowledgement_is_backchannel(self):
+        assert _is_backchannel_text("yeah ok") is True
+        assert _is_backchannel_text("got it") is True
+
+    def test_long_agreement_statement_is_not_backchannel(self):
+        assert _is_backchannel_text("yeah I think we should review the entire budget") is False
+
+    def test_substantive_content_is_not_backchannel(self):
+        assert _is_backchannel_text("Tuesday") is False
+        assert _is_backchannel_text("That's a hard problem to solve") is False
+
+    def test_empty_text_is_not_backchannel(self):
+        assert _is_backchannel_text("") is False
+        assert _is_backchannel_text("   ") is False
+
+
+class TestInterruptionDetection:
+    """AC1, AC2, AC3, BR-3.1 — overlapping turns produce interruption events
+    unless the interrupter's utterance is a back-channel."""
+
+    def test_overlap_with_substantive_content_is_interruption(self):
+        # A speaks 0-5, B starts at 3 and continues to 6 with substantive content
+        diarize_turns = [(0.0, 5.0, "A"), (3.0, 6.0, "B")]
+        segments = [
+            _seg("a0", 0.0, 5.0, speaker="A", text="we should review the entire budget plan"),
+            _seg("b0", 3.0, 6.0, speaker="B", text="actually I disagree with that approach"),
+        ]
+        result = analyze(segments, diarize_turns)
+        interruptions = [e for e in result.events if e.event_type == InteractionEventType.INTERRUPTION]
+        assert len(interruptions) == 1
+        ev = interruptions[0]
+        assert ev.speaker_a == "A"
+        assert ev.speaker_b == "B"
+        assert ev.timestamp == 3.0
+        assert ev.duration == 2.0
+        assert "actually" in ev.context.lower()
+
+    def test_backchannel_overlap_is_classified_as_overlap_not_interruption(self):
+        # A speaks 0-10, B drops a 0.5s "yeah" at 4.0
+        diarize_turns = [(0.0, 10.0, "A"), (4.0, 4.5, "B")]
+        segments = [
+            _seg("a0", 0.0, 10.0, speaker="A", text="and the timeline says we should ship by friday"),
+            _seg("b0", 4.0, 4.5, speaker="B", text="yeah"),
+        ]
+        result = analyze(segments, diarize_turns)
+        interruptions = [e for e in result.events if e.event_type == InteractionEventType.INTERRUPTION]
+        overlaps = [e for e in result.events if e.event_type == InteractionEventType.OVERLAP]
+        assert len(interruptions) == 0
+        assert len(overlaps) == 1
+        assert overlaps[0].speaker_b == "B"
+
+    def test_long_backchannel_phrase_is_still_interruption(self):
+        # If the back-channel turn exceeds duration cap, treat as interruption
+        diarize_turns = [(0.0, 10.0, "A"), (4.0, 4.0 + BACKCHANNEL_MAX_DURATION + 0.5, "B")]
+        segments = [
+            _seg("a0", 0.0, 10.0, speaker="A", text="we need to align on this"),
+            _seg("b0", 4.0, 4.0 + BACKCHANNEL_MAX_DURATION + 0.5, speaker="B", text="yeah"),
+        ]
+        result = analyze(segments, diarize_turns)
+        interruptions = [e for e in result.events if e.event_type == InteractionEventType.INTERRUPTION]
+        assert len(interruptions) == 1
+
+    def test_same_speaker_overlap_is_ignored(self):
+        # Adjacent turns by the same speaker — even with overlap — are not events
+        diarize_turns = [(0.0, 5.0, "A"), (4.0, 7.0, "A")]
+        segments = [_seg("a0", 0.0, 7.0, speaker="A", text="continuing thought across two turns")]
+        result = analyze(segments, diarize_turns)
+        assert result.events == []
+
+
+class TestPauseDetection:
+    """AC4, AC2 — gaps between turns produce hesitation/long_pause events."""
+
+    def test_short_gap_emits_no_event(self):
+        # 0.3s gap — below hesitation threshold
+        diarize_turns = [(0.0, 1.0, "A"), (1.3, 2.0, "B")]
+        segments = [
+            _seg("a0", 0.0, 1.0, speaker="A", text="any thoughts"),
+            _seg("b0", 1.3, 2.0, speaker="B", text="not really"),
+        ]
+        result = analyze(segments, diarize_turns)
+        events = [
+            e
+            for e in result.events
+            if e.event_type in {InteractionEventType.HESITATION, InteractionEventType.LONG_PAUSE}
+        ]
+        assert events == []
+
+    def test_medium_gap_emits_hesitation_event(self):
+        gap = HESITATION_MIN_SECONDS + 0.2
+        diarize_turns = [(0.0, 1.0, "A"), (1.0 + gap, 2.0 + gap, "B")]
+        segments = [
+            _seg("a0", 0.0, 1.0, speaker="A", text="how do you feel about it"),
+            _seg("b0", 1.0 + gap, 2.0 + gap, speaker="B", text="i'm not sure"),
+        ]
+        result = analyze(segments, diarize_turns)
+        hesitations = [e for e in result.events if e.event_type == InteractionEventType.HESITATION]
+        assert len(hesitations) == 1
+        assert hesitations[0].speaker_a == "A"
+        assert hesitations[0].speaker_b == "B"
+        assert hesitations[0].duration == round(gap, 2)
+
+    def test_large_gap_emits_long_pause_event(self):
+        gap = LONG_PAUSE_MIN_SECONDS + 0.5
+        diarize_turns = [(0.0, 1.0, "A"), (1.0 + gap, 2.0 + gap, "B")]
+        segments = [
+            _seg("a0", 0.0, 1.0, speaker="A", text="any objections"),
+            _seg("b0", 1.0 + gap, 2.0 + gap, speaker="B", text="well"),
+        ]
+        result = analyze(segments, diarize_turns)
+        long_pauses = [e for e in result.events if e.event_type == InteractionEventType.LONG_PAUSE]
+        assert len(long_pauses) == 1
+        assert long_pauses[0].duration == round(gap, 2)
+
+    def test_same_speaker_gap_is_ignored(self):
+        diarize_turns = [(0.0, 1.0, "A"), (5.0, 6.0, "A")]
+        segments = [_seg("a0", 0.0, 6.0, speaker="A", text="thinking")]
+        result = analyze(segments, diarize_turns)
+        assert result.events == []
+
+
+class TestSegmentInteractions:
+    """AC4, AC6, BR-3.3 — per-segment annotations."""
+
+    def test_hesitation_before_recorded_for_each_segment(self):
+        diarize_turns = [(0.0, 1.0, "A"), (2.5, 3.5, "B")]
+        segments = [
+            _seg("a0", 0.0, 1.0, speaker="A", text="ready"),
+            _seg("b0", 2.5, 3.5, speaker="B", text="yes"),
+        ]
+        result = analyze(segments, diarize_turns)
+        by_id = {s.segment_id: s for s in result.segment_interactions}
+        assert by_id["a0"].hesitation_before == 0.0
+        assert by_id["b0"].hesitation_before == 1.5
+
+    def test_interruption_marks_both_sides(self):
+        diarize_turns = [(0.0, 5.0, "A"), (3.0, 6.0, "B")]
+        segments = [
+            _seg("a0", 0.0, 5.0, speaker="A", text="i think we should do it this way"),
+            _seg("b0", 3.0, 6.0, speaker="B", text="hold on let me push back on that"),
+        ]
+        result = analyze(segments, diarize_turns)
+        by_id = {s.segment_id: s for s in result.segment_interactions}
+        assert by_id["b0"].preceded_by_interruption is True
+        assert by_id["a0"].followed_by_interruption is True
+
+    def test_backchannel_does_not_set_interruption_flags(self):
+        diarize_turns = [(0.0, 10.0, "A"), (4.0, 4.5, "B")]
+        segments = [
+            _seg("a0", 0.0, 10.0, speaker="A", text="and that's why we should proceed"),
+            _seg("b0", 4.0, 4.5, speaker="B", text="yeah"),
+        ]
+        result = analyze(segments, diarize_turns)
+        by_id = {s.segment_id: s for s in result.segment_interactions}
+        assert by_id["a0"].followed_by_interruption is False
+        assert by_id["b0"].preceded_by_interruption is False
+
+    def test_every_segment_has_annotation(self):
+        diarize_turns = [(0.0, 1.0, "A"), (1.5, 2.5, "B"), (3.0, 4.0, "A")]
+        segments = [
+            _seg("a0", 0.0, 1.0, speaker="A", text="one"),
+            _seg("b0", 1.5, 2.5, speaker="B", text="two"),
+            _seg("a1", 3.0, 4.0, speaker="A", text="three"),
+        ]
+        result = analyze(segments, diarize_turns)
+        ids = {s.segment_id for s in result.segment_interactions}
+        assert ids == {"a0", "b0", "a1"}
+
+
+class TestDominantSpeakerLimitation:
+    """AC5, BR-3.4 — single-speaker dominance is flagged but stage completes."""
+
+    def test_dominant_speaker_above_threshold_sets_flag(self):
+        # A speaks 9s, B speaks 1s → A holds 90% > 80%
+        diarize_turns = [(0.0, 9.0, "A"), (9.0, 10.0, "B")]
+        segments = [
+            _seg("a0", 0.0, 9.0, speaker="A", text="long monologue from A"),
+            _seg("b0", 9.0, 10.0, speaker="B", text="ok"),
+        ]
+        result = analyze(segments, diarize_turns)
+        assert result.dominant_speaker_limitation is True
+
+    def test_balanced_speakers_does_not_set_flag(self):
+        diarize_turns = [(0.0, 5.0, "A"), (5.0, 10.0, "B")]
+        segments = [
+            _seg("a0", 0.0, 5.0, speaker="A", text="balanced share"),
+            _seg("b0", 5.0, 10.0, speaker="B", text="balanced share"),
+        ]
+        result = analyze(segments, diarize_turns)
+        assert result.dominant_speaker_limitation is False
+
+    def test_threshold_constant_matches_spec(self):
+        assert DOMINANT_SPEAKER_THRESHOLD == 0.8
+
+    def test_dominant_meeting_still_completes_with_events(self):
+        # Even when dominance is flagged, the analyzer returns events normally
+        diarize_turns = [(0.0, 9.0, "A"), (4.0, 4.6, "B"), (9.0, 10.0, "B")]
+        segments = [
+            _seg("a0", 0.0, 9.0, speaker="A", text="a long monologue from speaker A"),
+            _seg("b0", 4.0, 4.6, speaker="B", text="yeah"),
+            _seg("b1", 9.0, 10.0, speaker="B", text="ok"),
+        ]
+        result = analyze(segments, diarize_turns)
+        assert result.dominant_speaker_limitation is True
+        # Back-channel still classified correctly (overlap, not interruption)
+        overlap_events = [e for e in result.events if e.event_type == InteractionEventType.OVERLAP]
+        assert len(overlap_events) == 1
+
+
+class TestEmptyInputs:
+    def test_empty_diarize_turns_returns_empty_result(self):
+        result = analyze([], [])
+        assert result.events == []
+        assert result.segment_interactions == []
+        assert result.dominant_speaker_limitation is False
+
+    def test_segments_without_turns_still_returns_segment_annotations(self):
+        segments = [_seg("a0", 0.0, 1.0, speaker="A", text="hi")]
+        result = analyze(segments, [])
+        assert len(result.segment_interactions) == 1
+        assert result.segment_interactions[0].segment_id == "a0"
+        assert result.segment_interactions[0].hesitation_before == 0.0

--- a/tests/unit/test_interaction_analyzer.py
+++ b/tests/unit/test_interaction_analyzer.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from backend.schemas import InteractionEventType, TranscriptSegment
 from backend.services.interaction_analyzer import (
     BACKCHANNEL_MAX_DURATION,
+    BACKCHANNEL_SHORT_DURATION,
     DOMINANT_SPEAKER_THRESHOLD,
     HESITATION_MIN_SECONDS,
     LONG_PAUSE_MIN_SECONDS,
+    _is_backchannel,
     _is_backchannel_text,
     analyze,
 )
@@ -38,6 +40,41 @@ class TestBackchannelTextHeuristic:
     def test_empty_text_is_not_backchannel(self):
         assert _is_backchannel_text("") is False
         assert _is_backchannel_text("   ") is False
+
+    def test_expanded_token_set_covers_common_acknowledgements(self):
+        # Production logs surfaced these escaping the original token list
+        for token in ["Nice.", "cool", "Great!", "perfect", "Awesome.", "makes sense", "fair enough", "agreed"]:
+            assert _is_backchannel_text(token) is True, f"{token!r} should be a back-channel"
+
+
+class TestBackchannelCombinedHeuristic:
+    """The combined check (duration cap + lexicon, OR sub-second + ≤2 words)."""
+
+    def test_short_lexical_match_is_backchannel(self):
+        assert _is_backchannel(0.4, "yeah") is True
+        assert _is_backchannel(1.2, "got it") is True
+
+    def test_long_lexical_match_is_not_backchannel(self):
+        # Above duration cap, lexical match alone isn't enough
+        assert _is_backchannel(BACKCHANNEL_MAX_DURATION + 0.1, "yeah") is False
+
+    def test_sub_second_unknown_word_is_backchannel_via_duration_floor(self):
+        # "Nice." escapes the original lexicon but is still clearly a back-channel
+        # at 0.13s. The duration floor catches it.
+        assert _is_backchannel(0.13, "Nice.") is True
+        assert _is_backchannel(BACKCHANNEL_SHORT_DURATION, "huh?") is True
+
+    def test_sub_second_long_phrase_is_not_backchannel(self):
+        # Even at sub-second, more than 2 words shouldn't trigger the floor
+        assert _is_backchannel(0.4, "the budget plan now") is False
+
+    def test_above_short_duration_unknown_word_is_not_backchannel(self):
+        # "Tuesday" at 0.8s — neither lexical nor under the short-duration floor
+        assert _is_backchannel(0.8, "Tuesday") is False
+
+    def test_empty_text_is_not_backchannel(self):
+        assert _is_backchannel(0.2, "") is False
+        assert _is_backchannel(0.2, "   ") is False
 
 
 class TestInterruptionDetection:
@@ -74,6 +111,21 @@ class TestInterruptionDetection:
         assert len(interruptions) == 0
         assert len(overlaps) == 1
         assert overlaps[0].speaker_b == "B"
+
+    def test_sub_second_unknown_word_is_overlap_not_interruption(self):
+        # Reproduces a production case: a 0.13s "Nice." was being classified as
+        # interruption because the token wasn't in the lexicon. The duration
+        # floor now catches it.
+        diarize_turns = [(0.0, 10.0, "A"), (4.0, 4.13, "B")]
+        segments = [
+            _seg("a0", 0.0, 10.0, speaker="A", text="and the timeline says we should ship by friday"),
+            _seg("b0", 4.0, 4.13, speaker="B", text="Nice."),
+        ]
+        result = analyze(segments, diarize_turns)
+        interruptions = [e for e in result.events if e.event_type == InteractionEventType.INTERRUPTION]
+        overlaps = [e for e in result.events if e.event_type == InteractionEventType.OVERLAP]
+        assert len(interruptions) == 0
+        assert len(overlaps) == 1
 
     def test_long_backchannel_phrase_is_still_interruption(self):
         # If the back-channel turn exceeds duration cap, treat as interruption

--- a/tests/unit/test_interaction_analyzer.py
+++ b/tests/unit/test_interaction_analyzer.py
@@ -324,3 +324,32 @@ class TestEmptyInputs:
         assert len(result.segment_interactions) == 1
         assert result.segment_interactions[0].segment_id == "a0"
         assert result.segment_interactions[0].hesitation_before == 0.0
+
+
+class TestPerformanceAtScale:
+    """Lock in the indexed-lookup + sweep-line optimization. The original
+    O(M² × N) implementation hung the interaction stage at 97% on hour-long
+    meetings (~750 segments, ~1000 turns). With the index + sweep this should
+    run in well under a second."""
+
+    def test_thousand_turns_completes_quickly(self):
+        import time
+
+        # 1000 non-overlapping turns alternating between two speakers,
+        # with 1000 matching transcript segments
+        turns = []
+        segments = []
+        for i in range(1000):
+            spk = "A" if i % 2 == 0 else "B"
+            start = i * 1.0
+            end = start + 0.9
+            turns.append((start, end, spk))
+            segments.append(_seg(f"s{i:04d}", start, end, speaker=spk, text="some words here"))
+
+        t0 = time.monotonic()
+        result = analyze(segments, turns)
+        elapsed = time.monotonic() - t0
+
+        assert len(result.segment_interactions) == 1000
+        # Generous bound — the original implementation took minutes here
+        assert elapsed < 2.0, f"analyze() took {elapsed:.2f}s on 1000 non-overlapping turns"

--- a/tests/unit/test_interaction_analyzer.py
+++ b/tests/unit/test_interaction_analyzer.py
@@ -72,9 +72,16 @@ class TestBackchannelCombinedHeuristic:
         # "Tuesday" at 0.8s — neither lexical nor under the short-duration floor
         assert _is_backchannel(0.8, "Tuesday") is False
 
-    def test_empty_text_is_not_backchannel(self):
-        assert _is_backchannel(0.2, "") is False
-        assert _is_backchannel(0.2, "   ") is False
+    def test_sub_floor_with_no_text_is_backchannel(self):
+        # A sub-0.5s PyAnnote turn that WhisperX didn't transcribe — almost
+        # always a brief vocalization or breath, not a real interruption.
+        assert _is_backchannel(0.2, "") is True
+        assert _is_backchannel(0.4, "   ") is True
+
+    def test_above_short_duration_with_no_text_is_not_backchannel(self):
+        # A 1s+ turn with no transcript shouldn't be auto-classified as
+        # back-channel — could be inaudible substantive speech
+        assert _is_backchannel(1.2, "") is False
 
 
 class TestInterruptionDetection:
@@ -111,6 +118,25 @@ class TestInterruptionDetection:
         assert len(interruptions) == 0
         assert len(overlaps) == 1
         assert overlaps[0].speaker_b == "B"
+
+    def test_brief_blip_with_no_transcript_is_overlap_not_interruption(self):
+        # Reproduces a production case: PyAnnote detected a 0.2s crossover by
+        # speaker B at t=4.0 but WhisperX didn't transcribe it. Speaker B's
+        # nearest transcript segment is 200s away with substantive content.
+        # Strict lookup must not pull that far-away text into the decision.
+        diarize_turns = [(0.0, 10.0, "A"), (4.0, 4.2, "B")]
+        segments = [
+            _seg("a0", 0.0, 10.0, speaker="A", text="and we should ship by friday for the launch"),
+            # B's only transcript segment is far away with substantive content
+            _seg("b0", 200.0, 210.0, speaker="B", text="actually the entire approach needs revisiting"),
+        ]
+        result = analyze(segments, diarize_turns)
+        interruptions = [e for e in result.events if e.event_type == InteractionEventType.INTERRUPTION]
+        overlaps = [e for e in result.events if e.event_type == InteractionEventType.OVERLAP]
+        assert len(interruptions) == 0
+        assert len(overlaps) == 1
+        # Lenient context should still surface something — better than empty
+        assert overlaps[0].context != ""
 
     def test_sub_second_unknown_word_is_overlap_not_interruption(self):
         # Reproduces a production case: a 0.13s "Nice." was being classified as

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -10,6 +10,8 @@ from backend.schemas import (
     AudioAnalysisStatus,
     EmotionAnnotation,
     EmotionCategory,
+    InteractionEvent,
+    InteractionEventType,
     JobInfo,
     JobStage,
     JobStatus,
@@ -21,6 +23,7 @@ from backend.schemas import (
     MeetingUpdate,
     ProsodyAnnotation,
     ProsodyUnavailable,
+    SegmentInteraction,
     SegmentSpeakerUpdate,
     Transcript,
     TranscriptSegment,
@@ -383,3 +386,76 @@ class TestAudioAnalysisProsodyFields:
         )
         assert a.emotion_status == AudioAnalysisStatus.UNAVAILABLE
         assert a.prosody_status == AudioAnalysisStatus.COMPLETED
+
+
+class TestInteractionSchemas:
+    def test_event_type_values(self):
+        assert InteractionEventType.INTERRUPTION == "interruption"
+        assert InteractionEventType.OVERLAP == "overlap"
+        assert InteractionEventType.LONG_PAUSE == "long_pause"
+        assert InteractionEventType.HESITATION == "hesitation"
+
+    def test_interaction_event_creation(self):
+        e = InteractionEvent(
+            event_type=InteractionEventType.INTERRUPTION,
+            timestamp=12.5,
+            speaker_a="SPEAKER_00",
+            speaker_b="SPEAKER_01",
+            duration=0.6,
+            context="and the budget needs to",
+        )
+        assert e.event_type == InteractionEventType.INTERRUPTION
+        assert e.timestamp == 12.5
+        assert e.duration == 0.6
+        assert e.context == "and the budget needs to"
+
+    def test_interaction_event_default_context(self):
+        e = InteractionEvent(
+            event_type=InteractionEventType.HESITATION,
+            timestamp=8.0,
+            speaker_a="A",
+            speaker_b="B",
+            duration=1.2,
+        )
+        assert e.context == ""
+
+    def test_segment_interaction_defaults(self):
+        s = SegmentInteraction(segment_id="seg-1")
+        assert s.preceded_by_interruption is False
+        assert s.followed_by_interruption is False
+        assert s.hesitation_before == 0.0
+
+    def test_audio_analysis_interaction_defaults(self):
+        a = AudioAnalysis(status=AudioAnalysisStatus.UNAVAILABLE)
+        assert a.interactions == []
+        assert a.segment_interactions == []
+        assert a.interaction_status is None
+        assert a.interaction_reason is None
+        assert a.dominant_speaker_limitation is False
+
+    def test_audio_analysis_with_interactions(self):
+        a = AudioAnalysis(
+            status=AudioAnalysisStatus.COMPLETED,
+            interaction_status=AudioAnalysisStatus.COMPLETED,
+            interactions=[
+                InteractionEvent(
+                    event_type=InteractionEventType.INTERRUPTION,
+                    timestamp=4.0,
+                    speaker_a="A",
+                    speaker_b="B",
+                    duration=0.4,
+                    context="say something",
+                )
+            ],
+            segment_interactions=[
+                SegmentInteraction(segment_id="seg-1", followed_by_interruption=True),
+                SegmentInteraction(segment_id="seg-2", preceded_by_interruption=True, hesitation_before=0.0),
+            ],
+            dominant_speaker_limitation=True,
+        )
+        assert len(a.interactions) == 1
+        assert a.dominant_speaker_limitation is True
+        assert a.segment_interactions[1].preceded_by_interruption is True
+
+    def test_job_stage_interaction_analysis(self):
+        assert JobStage.INTERACTION_ANALYSIS == "interaction_analysis"

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -502,16 +502,25 @@ class TestRunAudioAnalysis:
             {"id": "seg_0000", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_00", "text": "hi"},
         ]
 
+    def _diarize_turns(self):
+        return [(0.0, 1.0, "SPEAKER_00")]
+
     def test_unsupported_language_skips_emotion_but_runs_prosody(self):
         with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])) as mock_prosody:
             with patch("backend.services.transcriber.job_queue.update_job"):
                 result = _run_audio_analysis(
-                    job_id="j1", audio=MagicMock(), segments=self._segments(), detected_language="fr"
+                    job_id="j1",
+                    audio=MagicMock(),
+                    segments=self._segments(),
+                    detected_language="fr",
+                    diarize_turns=self._diarize_turns(),
                 )
         # Emotions skipped (English-only), prosody ran (language-agnostic, BR-2.1)
         assert result.emotion_status == AudioAnalysisStatus.UNAVAILABLE
         assert result.emotion_reason == "language_not_supported:fr"
         assert result.prosody_status == AudioAnalysisStatus.COMPLETED
+        # Interaction is also language-agnostic
+        assert result.interaction_status == AudioAnalysisStatus.COMPLETED
         # Pipeline status rolls up — completes when at least one stage produces output
         assert result.status == AudioAnalysisStatus.COMPLETED
         mock_prosody.assert_called_once()
@@ -525,10 +534,12 @@ class TestRunAudioAnalysis:
                         audio=MagicMock(),
                         segments=self._segments(),
                         detected_language="en",
+                        diarize_turns=self._diarize_turns(),
                     )
         assert result.status == AudioAnalysisStatus.COMPLETED
         assert result.emotion_status == AudioAnalysisStatus.COMPLETED
         assert result.prosody_status == AudioAnalysisStatus.COMPLETED
+        assert result.interaction_status == AudioAnalysisStatus.COMPLETED
         mock_emotion.assert_called_once()
         mock_prosody.assert_called_once()
 
@@ -544,6 +555,7 @@ class TestRunAudioAnalysis:
                         audio=MagicMock(),
                         segments=self._segments(),
                         detected_language="en",
+                        diarize_turns=self._diarize_turns(),
                     )
         # Emotion failed but prosody completed → overall COMPLETED
         assert result.emotion_status == AudioAnalysisStatus.FAILED
@@ -563,13 +575,14 @@ class TestRunAudioAnalysis:
                         audio=MagicMock(),
                         segments=self._segments(),
                         detected_language="en",
+                        diarize_turns=self._diarize_turns(),
                     )
         assert result.prosody_status == AudioAnalysisStatus.FAILED
         assert "praat crashed" in result.prosody_reason
         assert result.emotion_status == AudioAnalysisStatus.COMPLETED
         assert result.status == AudioAnalysisStatus.COMPLETED
 
-    def test_both_stages_fail_rolls_up_to_failed(self):
+    def test_all_stages_fail_rolls_up_to_failed(self):
         with patch(
             "backend.services.emotion_analyzer.analyze_segments",
             side_effect=RuntimeError("emotion boom"),
@@ -578,16 +591,22 @@ class TestRunAudioAnalysis:
                 "backend.services.prosody_analyzer.analyze_segments",
                 side_effect=RuntimeError("prosody boom"),
             ):
-                with patch("backend.services.transcriber.job_queue.update_job"):
-                    result = _run_audio_analysis(
-                        job_id="j1",
-                        audio=MagicMock(),
-                        segments=self._segments(),
-                        detected_language="en",
-                    )
+                with patch(
+                    "backend.services.interaction_analyzer.analyze",
+                    side_effect=RuntimeError("interaction boom"),
+                ):
+                    with patch("backend.services.transcriber.job_queue.update_job"):
+                        result = _run_audio_analysis(
+                            job_id="j1",
+                            audio=MagicMock(),
+                            segments=self._segments(),
+                            detected_language="en",
+                            diarize_turns=self._diarize_turns(),
+                        )
         assert result.status == AudioAnalysisStatus.FAILED
         assert result.emotion_status == AudioAnalysisStatus.FAILED
         assert result.prosody_status == AudioAnalysisStatus.FAILED
+        assert result.interaction_status == AudioAnalysisStatus.FAILED
 
     def test_prosody_unavailable_markers_propagated(self):
         from backend.schemas import ProsodyUnavailable
@@ -603,6 +622,77 @@ class TestRunAudioAnalysis:
                         audio=MagicMock(),
                         segments=self._segments(),
                         detected_language="en",
+                        diarize_turns=self._diarize_turns(),
                     )
         assert len(result.prosody_unavailable) == 1
         assert result.prosody_unavailable[0].reason == "non_speech"
+
+    def test_no_diarize_turns_marks_interaction_unavailable(self):
+        with patch("backend.services.emotion_analyzer.analyze_segments", return_value=[]):
+            with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])):
+                with patch("backend.services.transcriber.job_queue.update_job"):
+                    result = _run_audio_analysis(
+                        job_id="j1",
+                        audio=MagicMock(),
+                        segments=self._segments(),
+                        detected_language="en",
+                        diarize_turns=None,
+                    )
+        assert result.interaction_status == AudioAnalysisStatus.UNAVAILABLE
+        assert result.interaction_reason == "diarization_unavailable"
+        # Emotion + prosody still produced output → overall COMPLETED
+        assert result.status == AudioAnalysisStatus.COMPLETED
+
+    def test_interaction_failure_does_not_block_other_stages(self):
+        with patch("backend.services.emotion_analyzer.analyze_segments", return_value=[]):
+            with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])):
+                with patch(
+                    "backend.services.interaction_analyzer.analyze",
+                    side_effect=RuntimeError("interaction boom"),
+                ):
+                    with patch("backend.services.transcriber.job_queue.update_job"):
+                        result = _run_audio_analysis(
+                            job_id="j1",
+                            audio=MagicMock(),
+                            segments=self._segments(),
+                            detected_language="en",
+                            diarize_turns=self._diarize_turns(),
+                        )
+        assert result.interaction_status == AudioAnalysisStatus.FAILED
+        assert "interaction boom" in result.interaction_reason
+        assert result.status == AudioAnalysisStatus.COMPLETED
+
+    def test_interaction_results_propagated(self):
+        from backend.schemas import InteractionEvent, InteractionEventType, SegmentInteraction
+        from backend.services.interaction_analyzer import InteractionAnalysisResult
+
+        analyzer_result = InteractionAnalysisResult(
+            events=[
+                InteractionEvent(
+                    event_type=InteractionEventType.INTERRUPTION,
+                    timestamp=2.0,
+                    speaker_a="SPEAKER_00",
+                    speaker_b="SPEAKER_01",
+                    duration=0.5,
+                    context="hi",
+                )
+            ],
+            segment_interactions=[SegmentInteraction(segment_id="seg_0000", followed_by_interruption=True)],
+            dominant_speaker_limitation=True,
+        )
+        with patch("backend.services.emotion_analyzer.analyze_segments", return_value=[]):
+            with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])):
+                with patch("backend.services.interaction_analyzer.analyze", return_value=analyzer_result):
+                    with patch("backend.services.transcriber.job_queue.update_job"):
+                        result = _run_audio_analysis(
+                            job_id="j1",
+                            audio=MagicMock(),
+                            segments=self._segments(),
+                            detected_language="en",
+                            diarize_turns=self._diarize_turns(),
+                        )
+        assert len(result.interactions) == 1
+        assert result.interactions[0].event_type == InteractionEventType.INTERRUPTION
+        assert len(result.segment_interactions) == 1
+        assert result.segment_interactions[0].followed_by_interruption is True
+        assert result.dominant_speaker_limitation is True


### PR DESCRIPTION
Closes [#51](https://github.com/nimblehq/audio-transcriber/issues/51)

## Summary

Adds the third audio analysis stage — interaction pattern detection — to the opt-in audio analysis pipeline. Detects interruptions, overlaps, hesitations, and long pauses from PyAnnote diarization turns; annotates each transcript segment with `preceded_by_interruption`, `followed_by_interruption`, and `hesitation_before`; flags single-speaker dominance.

## Approach

- **Raw PyAnnote turns are captured** before `assign_word_speakers` collapses them, then passed to a new pure-logic `interaction_analyzer` module. WhisperX's per-speaker segments lose the overlap data, so true interruption detection (BR-3.1) requires the raw diarization.
- **Back-channel filter** (TD-2): an overlapping turn is reclassified from `interruption` to `overlap` when its duration ≤ 1.5s AND its transcript text is dominated by acknowledgement tokens (`yeah`, `mm-hmm`, `right`, etc.). Both conditions are required so short content words like "Tuesday" aren't mis-filtered and long agreement statements aren't mis-classified.
- **Pause thresholds** (TD-3): `hesitation` event fires for 0.7s ≤ gap < 3.0s between turns by different speakers; `long_pause` fires for gap ≥ 3.0s. `hesitation_before` per segment carries the gap from the prior turn regardless of whether an event was emitted.
- **Storage** (TD-4): continuing #49/#50, transcript schema is untouched. Per-segment annotations live in a new `segment_interactions: list[SegmentInteraction]` inside `AudioAnalysis`. Frontend joins by segment ID.
- **Dominance flag**: computed from total speaking duration per speaker on transcript segments; > 80% sets `dominant_speaker_limitation = True`. Stage still completes successfully (BR-3.4).
- **Best-effort, language-agnostic** — same pattern as prosody. Without diarization (no `HF_TOKEN`) the stage marks `UNAVAILABLE`. Stage failures don't block emotion or prosody output.

Plan: `docs/plans/51-interaction-pattern-detection.md`
Spec: `docs/specs/audio-emotional-intelligence.md`

## Verification

- `bin/python -m pytest tests/unit -q` → 165 passed
- `bin/ruff check backend/ tests/unit/` → all checks passed
- `bin/ruff format --check backend/ tests/unit/` → all formatted
- Architect review: APPROVE — no critical/major findings; 3 minor + 3 nit observations noted, all defensible-as-is and consistent with codebase patterns.

Tests cover all eight AC plus the four supporting business rules:
- Back-channel vs substantive overlap (AC3, BR-3.1, BR-3.2)
- Hesitation/long_pause threshold bands (AC2, AC4)
- Per-segment annotations including `hesitation_before` (AC4, AC6, BR-3.3)
- Dominance flag with stage still completing (AC5, BR-3.4)
- Pipeline roll-up across all three stages, including failure isolation
- Skipped when audio analysis opted out (AC7) — covered by existing #49 gate