### PR TITLE
[#63] Reuse existing speaker id when renaming a segment

### DIFF
--- a/backend/routers/meetings.py
+++ b/backend/routers/meetings.py
@@ -230,14 +230,21 @@ async def update_segment_speaker(meeting_id: str, update: SegmentSpeakerUpdate):
     if not segment:
         raise HTTPException(status_code=404, detail="Segment not found")
 
-    # Create a unique speaker ID for this segment
+    normalized = update.speaker_name.strip().casefold()
+    existing_id = next(
+        (sid for sid, name in metadata.speakers.items() if name.strip().casefold() == normalized),
+        None,
+    )
+
+    if existing_id is not None:
+        segment.speaker = existing_id
+        transcript_path.write_text(json.dumps(transcript.model_dump(), ensure_ascii=False, indent=2))
+        return {"ok": True}
+
     new_speaker_id = f"{segment.speaker}_seg_{update.segment_id}"
     segment.speaker = new_speaker_id
-
-    # Save updated transcript
     transcript_path.write_text(json.dumps(transcript.model_dump(), ensure_ascii=False, indent=2))
 
-    # Map the new speaker ID to the given name
     metadata.speakers[new_speaker_id] = update.speaker_name
     _save_metadata(metadata)
 

--- a/tests/integration/test_meetings.py
+++ b/tests/integration/test_meetings.py
@@ -243,6 +243,45 @@ class TestUpdateSegmentSpeaker:
         speakers = detail.json()["metadata"]["speakers"]
         assert "Charlie" in speakers.values()
 
+    async def test_merges_onto_existing_speaker(self, client, populated_meeting):
+        """Renaming to an existing speaker's name reuses that speaker's id."""
+        res = await client.patch(
+            f"/api/meetings/{populated_meeting}/segments/speaker",
+            json={"segment_id": "seg-001", "speaker_name": "Bob"},
+        )
+        assert res.status_code == 200
+
+        detail = (await client.get(f"/api/meetings/{populated_meeting}")).json()
+        assert detail["metadata"]["speakers"] == {"SPEAKER_00": "Alice", "SPEAKER_01": "Bob"}
+        seg = next(s for s in detail["transcript"]["segments"] if s["id"] == "seg-001")
+        assert seg["speaker"] == "SPEAKER_01"
+
+    async def test_merge_match_is_case_and_whitespace_insensitive(self, client, populated_meeting):
+        res = await client.patch(
+            f"/api/meetings/{populated_meeting}/segments/speaker",
+            json={"segment_id": "seg-001", "speaker_name": "  bob  "},
+        )
+        assert res.status_code == 200
+
+        detail = (await client.get(f"/api/meetings/{populated_meeting}")).json()
+        assert detail["metadata"]["speakers"] == {"SPEAKER_00": "Alice", "SPEAKER_01": "Bob"}
+        seg = next(s for s in detail["transcript"]["segments"] if s["id"] == "seg-001")
+        assert seg["speaker"] == "SPEAKER_01"
+
+    async def test_brand_new_name_creates_new_speaker(self, client, populated_meeting):
+        res = await client.patch(
+            f"/api/meetings/{populated_meeting}/segments/speaker",
+            json={"segment_id": "seg-001", "speaker_name": "Charlie"},
+        )
+        assert res.status_code == 200
+
+        detail = (await client.get(f"/api/meetings/{populated_meeting}")).json()
+        speakers = detail["metadata"]["speakers"]
+        assert "Charlie" in speakers.values()
+        assert len(speakers) == 3
+        seg = next(s for s in detail["transcript"]["segments"] if s["id"] == "seg-001")
+        assert speakers[seg["speaker"]] == "Charlie"
+
     async def test_missing_segment(self, client, populated_meeting):
         res = await client.patch(
             f"/api/meetings/{populated_meeting}/segments/speaker",


### PR DESCRIPTION
Closes #63.

## Summary

- Renaming a single segment's speaker via "this segment only" no longer creates a duplicate `metadata.speakers` entry when the typed name matches an existing speaker. The handler now scans the speakers dict (case-insensitive, whitespace-trimmed) and reuses the matching id.
- Brand-new names still mint a fresh id, preserving the original behavior.
- Reusing the existing id automatically restores color consistency in the UI, since the frontend assigns colors by speaker index.

## Changes

- `backend/routers/meetings.py` — `update_segment_speaker` looks up an existing speaker by case-folded, trimmed name before falling through to mint a new id.
- `tests/integration/test_meetings.py` — three new tests in `TestUpdateSegmentSpeaker`: merge onto existing speaker, case- and whitespace-insensitive merge, and the regression guard for genuinely new names.

## Test plan

- [x] `pytest tests/integration/test_meetings.py::TestUpdateSegmentSpeaker` (6/6)
- [x] `pytest` full suite (178/178)
- [x] `ruff check` clean
- [ ] Manual UI: rename one segment to an existing speaker name and confirm no duplicate appears in the speaker list and the color stays consistent