### PR TITLE
[#52] Add audio analysis context to LLM analysis prompts

### DIFF
--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+import json
+
 from fastapi import APIRouter, HTTPException
 
-from config import TEMPLATES_DIR
+from backend.schemas import AudioAnalysis, AudioAnalysisStatus, MeetingMetadata, Transcript
+from backend.services import analysis_context
+from config import MEETINGS_DIR, TEMPLATES_DIR
 
 router = APIRouter()
 
@@ -24,3 +30,42 @@ async def get_template(template_type: str):
         raise HTTPException(status_code=404, detail="Template file not found")
 
     return {"template": template_path.read_text(encoding="utf-8")}
+
+
+@router.get("/meetings/{meeting_id}/analysis-context")
+async def get_analysis_context(meeting_id: str):
+    """Return the rendered Audio Analysis Context markdown for a meeting.
+
+    Returns an empty string when the meeting is opted out of audio analysis,
+    so the analysis prompt remains byte-identical to the pre-feature output
+    (BR-4.4). Returns a brief unavailability note when audio analysis was
+    attempted but produced no usable output.
+    """
+    meeting_dir = MEETINGS_DIR / meeting_id
+    metadata_path = meeting_dir / "metadata.json"
+    if not metadata_path.exists():
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    metadata = MeetingMetadata(**json.loads(metadata_path.read_text(encoding="utf-8")))
+
+    if not metadata.audio_analysis_enabled:
+        return {"context": ""}
+
+    audio_analysis_path = meeting_dir / "audio_analysis.json"
+    if audio_analysis_path.exists():
+        audio_analysis = AudioAnalysis(**json.loads(audio_analysis_path.read_text(encoding="utf-8")))
+    else:
+        # Opted in but no audio_analysis.json on disk — treat as unavailable so
+        # the prompt discloses the gap (BR-4.5).
+        audio_analysis = AudioAnalysis(
+            status=AudioAnalysisStatus.UNAVAILABLE,
+            reason="audio analysis has not produced output for this meeting",
+        )
+
+    transcript: Transcript | None = None
+    transcript_path = meeting_dir / "transcript.json"
+    if transcript_path.exists():
+        transcript = Transcript(**json.loads(transcript_path.read_text(encoding="utf-8")))
+
+    rendered = analysis_context.render(audio_analysis, transcript, speakers=metadata.speakers)
+    return {"context": rendered}

--- a/backend/services/analysis_context.py
+++ b/backend/services/analysis_context.py
@@ -101,6 +101,7 @@ def render(
             audio_analysis.dominant_speaker_limitation,
         ),
         _render_energy_trajectory(audio_analysis.emotions),
+        _render_data_limitations(audio_analysis.prosody_unavailable),
     ]
 
     body = "\n\n".join(s for s in sections if s)
@@ -336,6 +337,22 @@ def _window_label(index: int) -> str:
     start = int(index * ENERGY_WINDOW_SECONDS)
     end = int(start + ENERGY_WINDOW_SECONDS)
     return f"{_format_timestamp(start)}–{_format_timestamp(end)}"
+
+
+def _render_data_limitations(prosody_unavailable: list) -> str:
+    """Disclose non-speech / unanalyzable segments excluded from prosody (BR-4.5)."""
+    if not prosody_unavailable:
+        return ""
+
+    reasons: Counter[str] = Counter(item.reason for item in prosody_unavailable)
+    parts = [f"{count} {reason}" for reason, count in reasons.most_common()]
+    summary = ", ".join(parts)
+    total = len(prosody_unavailable)
+    return (
+        "### Data Limitations\n"
+        f"- {total} segment{_s(total)} excluded from prosodic analysis ({summary}); "
+        "tone signals for those segments are unavailable."
+    )
 
 
 def _instructions() -> str:

--- a/backend/services/analysis_context.py
+++ b/backend/services/analysis_context.py
@@ -1,0 +1,364 @@
+"""Render the Audio Analysis Context section that gets injected into LLM
+analysis prompts.
+
+The output is a markdown string. When a meeting is opted out of audio
+analysis, the function returns an empty string so the prompt stays
+byte-identical to today's output (BR-4.4).
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Iterable
+
+from backend.schemas import (
+    AudioAnalysis,
+    AudioAnalysisStatus,
+    EmotionAnnotation,
+    EmotionCategory,
+    InteractionEvent,
+    InteractionEventType,
+    SegmentInteraction,
+    Transcript,
+    TranscriptSegment,
+)
+
+# Confidence threshold below which any emotion claim is hedged (BR-4.2).
+LOW_CONFIDENCE_THRESHOLD = 0.5
+
+# Strong-signal threshold for surfacing emotional spikes.
+SPIKE_CONFIDENCE_THRESHOLD = 0.7
+
+# Energy-trajectory window size in seconds.
+ENERGY_WINDOW_SECONDS = 300.0
+
+# Maximum quoted excerpt length for word-tone mismatches.
+MISMATCH_EXCERPT_CHARS = 80
+
+# Phrases that read as agreement / acceptance in transcript text. When
+# co-occurring with frustrated or uncertain tone, they form a word-tone
+# mismatch worth surfacing.
+AGREEMENT_PHRASES = (
+    "works for me",
+    "sounds good",
+    "that's fine",
+    "thats fine",
+    "no concerns",
+    "no issues",
+    "no problem",
+    "i agree",
+    "agreed",
+    "sure thing",
+    "fine by me",
+    "looks good",
+    "all good",
+    "happy with that",
+    "i'm good",
+    "im good",
+    "makes sense",
+    "i'm okay with",
+    "im okay with",
+    "i'm fine with",
+    "im fine with",
+)
+
+MISMATCH_EMOTIONS = {EmotionCategory.FRUSTRATED, EmotionCategory.UNCERTAIN}
+
+ENERGY_POSITIVE = {EmotionCategory.ENGAGED, EmotionCategory.CONFIDENT}
+ENERGY_NEGATIVE = {EmotionCategory.DISENGAGED, EmotionCategory.FRUSTRATED}
+
+
+def render(
+    audio_analysis: AudioAnalysis | None,
+    transcript: Transcript | None,
+    speakers: dict[str, str] | None = None,
+) -> str:
+    """Render the Audio Analysis Context markdown block.
+
+    Returns "" when the meeting is opted out of audio analysis (BR-4.4).
+    Returns a short unavailability note when audio analysis was attempted but
+    produced no output (failed or unavailable). Otherwise returns the full
+    Audio Analysis Context section followed by template-agnostic LLM
+    instructions on how to weight the signals.
+    """
+    if audio_analysis is None:
+        return ""
+
+    if audio_analysis.status != AudioAnalysisStatus.COMPLETED:
+        return _render_unavailable(audio_analysis)
+
+    speaker_names = speakers or {}
+    segments_by_id = _index_segments(transcript)
+
+    sections = [
+        _render_emotional_patterns(audio_analysis.emotions, speaker_names),
+        _render_word_tone_mismatches(audio_analysis.emotions, segments_by_id, speaker_names),
+        _render_interaction_dynamics(
+            audio_analysis.interactions,
+            audio_analysis.segment_interactions,
+            segments_by_id,
+            speaker_names,
+            audio_analysis.dominant_speaker_limitation,
+        ),
+        _render_energy_trajectory(audio_analysis.emotions),
+    ]
+
+    body = "\n\n".join(s for s in sections if s)
+    if not body:
+        return _render_unavailable(audio_analysis)
+
+    return "## Audio Analysis Context\n\n" + body + "\n\n" + _instructions()
+
+
+def _render_unavailable(audio_analysis: AudioAnalysis) -> str:
+    reason = audio_analysis.reason or "audio analysis was not produced for this meeting"
+    return (
+        "## Audio Analysis Context\n\n"
+        f"_Audio analysis was unavailable for this meeting ({reason}). Analyze the transcript "
+        "without audio context._"
+    )
+
+
+def _index_segments(transcript: Transcript | None) -> dict[str, TranscriptSegment]:
+    if transcript is None:
+        return {}
+    return {seg.id: seg for seg in transcript.segments}
+
+
+def _display_speaker(speaker_id: str, speaker_names: dict[str, str]) -> str:
+    return speaker_names.get(speaker_id, speaker_id)
+
+
+def _format_timestamp(seconds: float) -> str:
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def _render_emotional_patterns(
+    emotions: list[EmotionAnnotation],
+    speaker_names: dict[str, str],
+) -> str:
+    if not emotions:
+        return ""
+
+    by_speaker: dict[str, list[EmotionAnnotation]] = defaultdict(list)
+    for ann in emotions:
+        by_speaker[ann.speaker].append(ann)
+
+    lines = ["### Emotional Patterns"]
+    for speaker_id in sorted(by_speaker.keys()):
+        anns = by_speaker[speaker_id]
+        counter: Counter[EmotionCategory] = Counter(a.primary_emotion for a in anns)
+        total = sum(counter.values())
+        primary, primary_count = counter.most_common(1)[0]
+        primary_pct = round(100 * primary_count / total)
+
+        spikes = [
+            a for a in anns if a.primary_emotion in MISMATCH_EMOTIONS and a.confidence >= SPIKE_CONFIDENCE_THRESHOLD
+        ]
+        spikes.sort(key=lambda a: a.start)
+        spike_text = ""
+        if spikes:
+            spike_label = ", ".join(f"{a.primary_emotion.value} at {_format_timestamp(a.start)}" for a in spikes[:5])
+            if len(spikes) > 5:
+                spike_label += f" (+{len(spikes) - 5} more)"
+            spike_text = f"; spikes: {spike_label}"
+
+        name = _display_speaker(speaker_id, speaker_names)
+        lines.append(f"- {name}: predominantly {primary.value} ({primary_pct}%){spike_text}")
+
+    return "\n".join(lines)
+
+
+def _excerpt(text: str, limit: int = MISMATCH_EXCERPT_CHARS) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _render_word_tone_mismatches(
+    emotions: list[EmotionAnnotation],
+    segments_by_id: dict[str, TranscriptSegment],
+    speaker_names: dict[str, str],
+) -> str:
+    if not emotions or not segments_by_id:
+        return ""
+
+    matches: list[tuple[EmotionAnnotation, TranscriptSegment]] = []
+    for ann in emotions:
+        if ann.primary_emotion not in MISMATCH_EMOTIONS:
+            continue
+        seg = segments_by_id.get(ann.segment_id)
+        if seg is None:
+            continue
+        if not _text_signals_agreement(seg.text):
+            continue
+        matches.append((ann, seg))
+
+    if not matches:
+        return ""
+
+    matches.sort(key=lambda pair: pair[1].start)
+
+    lines = ["### Word-Tone Mismatches"]
+    for ann, seg in matches:
+        name = _display_speaker(seg.speaker, speaker_names)
+        verb = "may indicate" if ann.confidence < LOW_CONFIDENCE_THRESHOLD else "indicates"
+        lines.append(
+            f'- [{_format_timestamp(seg.start)}] {name}: "{_excerpt(seg.text)}" — '
+            f"tone {verb} {ann.primary_emotion.value} (confidence: {ann.confidence:.2f})"
+        )
+    return "\n".join(lines)
+
+
+def _text_signals_agreement(text: str) -> bool:
+    normalized = text.lower()
+    return any(phrase in normalized for phrase in AGREEMENT_PHRASES)
+
+
+def _render_interaction_dynamics(
+    events: list[InteractionEvent],
+    segment_interactions: list[SegmentInteraction],
+    segments_by_id: dict[str, TranscriptSegment],
+    speaker_names: dict[str, str],
+    dominant_speaker_limitation: bool,
+) -> str:
+    has_interactions = bool(events) or any(si.hesitation_before > 0 for si in segment_interactions)
+    if not has_interactions and not dominant_speaker_limitation:
+        return ""
+
+    lines = ["### Interaction Dynamics"]
+
+    interruptions = [e for e in events if e.event_type == InteractionEventType.INTERRUPTION]
+    if interruptions:
+        pair_counts: Counter[tuple[str, str]] = Counter()
+        for ev in interruptions:
+            pair_counts[(ev.speaker_b, ev.speaker_a)] += 1  # b interrupted a
+        for (interrupter, interrupted), count in pair_counts.most_common(5):
+            reverse = pair_counts.get((interrupted, interrupter), 0)
+            i_name = _display_speaker(interrupter, speaker_names)
+            t_name = _display_speaker(interrupted, speaker_names)
+            lines.append(f"- {i_name} interrupted {t_name} {count} time{_s(count)} (reverse: {reverse})")
+
+    latencies = _average_response_latency(segment_interactions, segments_by_id)
+    if latencies:
+        parts = [f"{_display_speaker(spk, speaker_names)} ({avg:.1f}s)" for spk, avg in latencies]
+        lines.append(f"- Average response latency: {', '.join(parts)}")
+
+    hesitations = [e for e in events if e.event_type == InteractionEventType.HESITATION]
+    if hesitations:
+        hesitations.sort(key=lambda e: e.duration, reverse=True)
+        notable = hesitations[:3]
+        for ev in notable:
+            name = _display_speaker(ev.speaker_a, speaker_names)
+            lines.append(f"- Notable hesitation: {name} paused {ev.duration:.1f}s at {_format_timestamp(ev.timestamp)}")
+
+    if dominant_speaker_limitation:
+        lines.append(
+            "- _Limited interaction data: a single speaker dominates this meeting, "
+            "so interruption and turn-taking signals are sparse._"
+        )
+
+    if len(lines) == 1:
+        return ""
+    return "\n".join(lines)
+
+
+def _s(count: int) -> str:
+    return "" if count == 1 else "s"
+
+
+def _average_response_latency(
+    segment_interactions: list[SegmentInteraction],
+    segments_by_id: dict[str, TranscriptSegment],
+) -> list[tuple[str, float]]:
+    by_speaker: dict[str, list[float]] = defaultdict(list)
+    for si in segment_interactions:
+        if si.hesitation_before <= 0:
+            continue
+        seg = segments_by_id.get(si.segment_id)
+        if seg is None:
+            continue
+        by_speaker[seg.speaker].append(si.hesitation_before)
+
+    averages = [(spk, sum(vals) / len(vals)) for spk, vals in by_speaker.items() if vals]
+    averages.sort(key=lambda pair: pair[0])
+    return averages
+
+
+def _render_energy_trajectory(emotions: list[EmotionAnnotation]) -> str:
+    if not emotions:
+        return ""
+
+    end = max(a.end for a in emotions)
+    if end <= 0:
+        return ""
+
+    windows: list[list[float]] = []
+    n_windows = max(1, int(end // ENERGY_WINDOW_SECONDS) + 1)
+    for _ in range(n_windows):
+        windows.append([])
+
+    for ann in emotions:
+        idx = min(int(ann.start // ENERGY_WINDOW_SECONDS), n_windows - 1)
+        windows[idx].append(_energy_score(ann))
+
+    averaged = []
+    for i, scores in enumerate(windows):
+        if not scores:
+            continue
+        averaged.append((i, sum(scores) / len(scores)))
+
+    if not averaged:
+        return ""
+
+    peak = max(averaged, key=lambda pair: pair[1])
+    trough = min(averaged, key=lambda pair: pair[1])
+
+    lines = ["### Energy Trajectory"]
+    lines.append(f"- Energy peaked during {_window_label(peak[0])} (score {peak[1]:+.2f})")
+    if trough[0] != peak[0]:
+        lines.append(f"- Energy lowest during {_window_label(trough[0])} (score {trough[1]:+.2f})")
+    return "\n".join(lines)
+
+
+def _energy_score(ann: EmotionAnnotation) -> float:
+    if ann.primary_emotion in ENERGY_POSITIVE:
+        return ann.confidence
+    if ann.primary_emotion in ENERGY_NEGATIVE:
+        return -ann.confidence
+    return 0.0
+
+
+def _window_label(index: int) -> str:
+    start = int(index * ENERGY_WINDOW_SECONDS)
+    end = int(start + ENERGY_WINDOW_SECONDS)
+    return f"{_format_timestamp(start)}–{_format_timestamp(end)}"
+
+
+def _instructions() -> str:
+    return (
+        "## Audio Analysis Instructions\n\n"
+        "Factor the audio context into your assessment alongside the transcript:\n\n"
+        "1. **Hidden disagreements:** Weight word-tone mismatches heavily. Verbal "
+        "agreement paired with frustrated or uncertain tone is likely not genuine "
+        "alignment — flag it as an unresolved or potential issue rather than a "
+        "settled point.\n"
+        "2. **Contribution quality:** A confident assertion carries more influence "
+        "than the same words said with uncertainty. Weight contributions by tone, "
+        "not just volume of speech.\n"
+        "3. **Psychological safety:** Hesitation patterns, asymmetric interruption "
+        "counts, and one-directional dominance reveal power dynamics. Surface them "
+        "when they affect who speaks freely and who self-censors.\n"
+        "4. **Meeting effectiveness:** Track the energy trajectory. A meeting that "
+        "ends in a low-energy or disengaged window is less likely to produce "
+        "follow-through, regardless of the commitments made.\n\n"
+        "Confidence levels are reported alongside emotional claims. Low-confidence "
+        "claims are already hedged in the context above — preserve that hedging in "
+        "your output rather than asserting them as fact.\n"
+    )
+
+
+__all__: Iterable[str] = ("render",)

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -69,6 +69,12 @@ const API = {
         return res.json();
     },
 
+    async getAnalysisContext(meetingId) {
+        const res = await fetch(`/api/meetings/${meetingId}/analysis-context`);
+        if (!res.ok) throw new Error('Failed to fetch analysis context');
+        return res.json();
+    },
+
     async updateSegmentSpeaker(meetingId, segmentId, speakerName) {
         const res = await fetch(`/api/meetings/${meetingId}/segments/speaker`, {
             method: 'PATCH',

--- a/frontend/js/components/analysis-viewer.js
+++ b/frontend/js/components/analysis-viewer.js
@@ -1,4 +1,5 @@
 function renderAnalysisTab(container, meetingId, meetingType) {
+    if (meetingId) container.dataset.meetingId = meetingId;
     container.innerHTML = `
         <div class="analysis-generator">
             <p>Select a template to generate a prompt you can paste into any LLM for analysis.</p>
@@ -22,14 +23,27 @@ function renderAnalysisTab(container, meetingId, meetingType) {
 async function handleGeneratePrompt() {
     const btn = document.getElementById('generate-prompt-btn');
     const type = document.getElementById('analysis-type').value;
+    const tabContainer = document.getElementById('analysis-tab');
+    const meetingId = tabContainer ? tabContainer.dataset.meetingId : '';
     btn.disabled = true;
     btn.textContent = 'Generating...';
 
     try {
-        const result = await API.getTemplate(type);
+        const [templateResult, audioContextResult] = await Promise.all([
+            API.getTemplate(type),
+            meetingId ? API.getAnalysisContext(meetingId) : Promise.resolve({ context: '' }),
+        ]);
         const transcript = buildPlainTextTranscript();
         const context = getMeetingContext();
-        let prompt = result.template;
+        const audioContext = audioContextResult.context || '';
+        let prompt = templateResult.template;
+        if (audioContext) {
+            prompt = prompt.replace('[AUDIO ANALYSIS CONTEXT]', audioContext);
+        } else {
+            // Strip the placeholder line entirely so the prompt remains
+            // byte-identical to the pre-feature output (BR-4.4).
+            prompt = prompt.replace('[AUDIO ANALYSIS CONTEXT]\n', '');
+        }
         if (context) {
             prompt = prompt.replace('[MEETING CONTEXT]', '## Meeting Context\n\n' + context);
         } else {
@@ -37,8 +51,7 @@ async function handleGeneratePrompt() {
         }
         prompt = prompt.replace('[PASTE TRANSCRIPT HERE]', transcript);
 
-        const container = document.getElementById('analysis-tab');
-        renderPromptContent(container, prompt);
+        renderPromptContent(tabContainer, prompt);
     } catch (err) {
         showToast(err.message, 'error');
         btn.disabled = false;

--- a/templates/client_meeting_analysis.md
+++ b/templates/client_meeting_analysis.md
@@ -238,6 +238,7 @@ Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 *Summary prepared by Nimble*
 ```
 
+[AUDIO ANALYSIS CONTEXT]
 ## Transcript
 
 [MEETING CONTEXT]

--- a/templates/interview_analysis.md
+++ b/templates/interview_analysis.md
@@ -158,6 +158,7 @@ Analyze the transcript and produce a structured evaluation. Be specific — cite
 
 ---
 
+[AUDIO ANALYSIS CONTEXT]
 ## Transcript
 
 [MEETING CONTEXT]

--- a/templates/other.md
+++ b/templates/other.md
@@ -153,6 +153,7 @@ Categories: Confusion | Misunderstanding | Hidden Disagreement | Unresolved
 `XX% talk | XQ | X adopted | driver:[y/n] | hedge:X | commits:[s/m/v]`
 ```
 
+[AUDIO ANALYSIS CONTEXT]
 ## Transcript
 
 [MEETING CONTEXT]

--- a/templates/sales_meeting_analysis.md
+++ b/templates/sales_meeting_analysis.md
@@ -223,6 +223,7 @@ Best regards,
 [Your name]
 ```
 
+[AUDIO ANALYSIS CONTEXT]
 ## Transcript
 
 [MEETING CONTEXT]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,10 +56,14 @@ async def client(data_dir: Path) -> AsyncClient:
     config_module.MEETINGS_DIR = data_dir / "meetings"
 
     # Also patch the routers module that may have imported these
+    import backend.routers.analysis as analysis_module
     import backend.routers.meetings as meetings_module
 
     original_router_meetings_dir = getattr(meetings_module, "MEETINGS_DIR", None)
     meetings_module.MEETINGS_DIR = data_dir / "meetings"
+
+    original_analysis_meetings_dir = getattr(analysis_module, "MEETINGS_DIR", None)
+    analysis_module.MEETINGS_DIR = data_dir / "meetings"
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -69,6 +73,8 @@ async def client(data_dir: Path) -> AsyncClient:
     config_module.MEETINGS_DIR = original_meetings_dir
     if original_router_meetings_dir is not None:
         meetings_module.MEETINGS_DIR = original_router_meetings_dir
+    if original_analysis_meetings_dir is not None:
+        analysis_module.MEETINGS_DIR = original_analysis_meetings_dir
 
 
 @pytest.fixture

--- a/tests/integration/test_analysis_context.py
+++ b/tests/integration/test_analysis_context.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+@pytest.fixture
+def base_metadata() -> dict:
+    return json.loads((FIXTURES_DIR / "metadata.json").read_text())
+
+
+@pytest.fixture
+def base_transcript() -> dict:
+    return json.loads((FIXTURES_DIR / "transcript.json").read_text())
+
+
+def _write_meeting(
+    meetings_dir: Path,
+    sample_audio: Path,
+    metadata: dict,
+    transcript: dict | None = None,
+    audio_analysis: dict | None = None,
+) -> str:
+    meeting_id = metadata["id"]
+    meeting_dir = meetings_dir / meeting_id
+    meeting_dir.mkdir()
+    (meeting_dir / "metadata.json").write_text(json.dumps(metadata))
+    if transcript is not None:
+        (meeting_dir / "transcript.json").write_text(json.dumps(transcript))
+    if audio_analysis is not None:
+        (meeting_dir / "audio_analysis.json").write_text(json.dumps(audio_analysis))
+    shutil.copy(sample_audio, meeting_dir / metadata["audio_filename"])
+    return meeting_id
+
+
+class TestGetAnalysisContext:
+    async def test_returns_404_when_meeting_not_found(self, client):
+        res = await client.get("/api/meetings/missing/analysis-context")
+        assert res.status_code == 404
+
+    async def test_opted_out_meeting_returns_empty_context(
+        self,
+        client,
+        meetings_dir: Path,
+        sample_audio: Path,
+        base_metadata: dict,
+        base_transcript: dict,
+    ):
+        # audio_analysis_enabled defaults to False — BR-4.4 backward compat.
+        base_metadata["audio_analysis_enabled"] = False
+        meeting_id = _write_meeting(meetings_dir, sample_audio, base_metadata, base_transcript)
+
+        res = await client.get(f"/api/meetings/{meeting_id}/analysis-context")
+        assert res.status_code == 200
+        assert res.json() == {"context": ""}
+
+    async def test_opted_in_with_no_audio_analysis_file_returns_unavailability_note(
+        self,
+        client,
+        meetings_dir: Path,
+        sample_audio: Path,
+        base_metadata: dict,
+        base_transcript: dict,
+    ):
+        base_metadata["audio_analysis_enabled"] = True
+        meeting_id = _write_meeting(meetings_dir, sample_audio, base_metadata, base_transcript)
+
+        res = await client.get(f"/api/meetings/{meeting_id}/analysis-context")
+        assert res.status_code == 200
+        ctx = res.json()["context"]
+        assert "## Audio Analysis Context" in ctx
+        assert "unavailable" in ctx
+        assert "## Audio Analysis Instructions" not in ctx
+
+    async def test_opted_in_with_failed_status_returns_unavailability_note(
+        self,
+        client,
+        meetings_dir: Path,
+        sample_audio: Path,
+        base_metadata: dict,
+        base_transcript: dict,
+    ):
+        base_metadata["audio_analysis_enabled"] = True
+        audio_analysis = {
+            "status": "failed",
+            "reason": "model_load_error",
+            "emotions": [],
+            "prosody": [],
+            "prosody_unavailable": [],
+            "interactions": [],
+            "segment_interactions": [],
+            "dominant_speaker_limitation": False,
+        }
+        meeting_id = _write_meeting(meetings_dir, sample_audio, base_metadata, base_transcript, audio_analysis)
+
+        res = await client.get(f"/api/meetings/{meeting_id}/analysis-context")
+        assert res.status_code == 200
+        ctx = res.json()["context"]
+        assert "model_load_error" in ctx
+        assert "## Audio Analysis Instructions" not in ctx
+
+    async def test_opted_in_completed_returns_full_context_with_speaker_names(
+        self,
+        client,
+        meetings_dir: Path,
+        sample_audio: Path,
+        base_metadata: dict,
+        base_transcript: dict,
+    ):
+        base_metadata["audio_analysis_enabled"] = True
+        # speakers in fixture: SPEAKER_00 -> Alice, SPEAKER_01 -> Bob
+        audio_analysis = {
+            "status": "completed",
+            "emotion_status": "completed",
+            "prosody_status": "completed",
+            "interaction_status": "completed",
+            "emotions": [
+                {
+                    "segment_id": "seg-001",
+                    "speaker": "SPEAKER_00",
+                    "start": 0.0,
+                    "end": 5.2,
+                    "primary_emotion": "engaged",
+                    "confidence": 0.92,
+                    "emotion_scores": {"engaged": 0.92},
+                    "low_confidence": False,
+                },
+                {
+                    "segment_id": "seg-003",
+                    "speaker": "SPEAKER_00",
+                    "start": 13.0,
+                    "end": 20.1,
+                    "primary_emotion": "frustrated",
+                    "confidence": 0.81,
+                    "emotion_scores": {"frustrated": 0.81},
+                    "low_confidence": False,
+                },
+            ],
+            "prosody": [],
+            "prosody_unavailable": [],
+            "interactions": [
+                {
+                    "event_type": "interruption",
+                    "timestamp": 12.0,
+                    "speaker_a": "SPEAKER_00",
+                    "speaker_b": "SPEAKER_01",
+                    "duration": 0.5,
+                    "context": "",
+                }
+            ],
+            "segment_interactions": [],
+            "dominant_speaker_limitation": False,
+        }
+        # seg-003 = "Great, go ahead." — change to an agreement phrase to surface a mismatch.
+        base_transcript["segments"][2]["text"] = "Sounds good to me."
+
+        meeting_id = _write_meeting(meetings_dir, sample_audio, base_metadata, base_transcript, audio_analysis)
+
+        res = await client.get(f"/api/meetings/{meeting_id}/analysis-context")
+        assert res.status_code == 200
+        ctx = res.json()["context"]
+        assert "## Audio Analysis Context" in ctx
+        assert "### Emotional Patterns" in ctx
+        # speaker display names
+        assert "Alice" in ctx
+        assert "Bob" in ctx
+        # word-tone mismatch
+        assert "### Word-Tone Mismatches" in ctx
+        assert "Sounds good to me." in ctx
+        # interaction dynamics
+        assert "### Interaction Dynamics" in ctx
+        assert "Bob interrupted Alice 1 time" in ctx
+        # template-agnostic instructions appended
+        assert "## Audio Analysis Instructions" in ctx
+
+    async def test_dominant_speaker_limitation_disclosed(
+        self,
+        client,
+        meetings_dir: Path,
+        sample_audio: Path,
+        base_metadata: dict,
+        base_transcript: dict,
+    ):
+        base_metadata["audio_analysis_enabled"] = True
+        audio_analysis = {
+            "status": "completed",
+            "emotion_status": "completed",
+            "interaction_status": "completed",
+            "emotions": [
+                {
+                    "segment_id": "seg-001",
+                    "speaker": "SPEAKER_00",
+                    "start": 0.0,
+                    "end": 5.2,
+                    "primary_emotion": "engaged",
+                    "confidence": 0.9,
+                    "emotion_scores": {"engaged": 0.9},
+                    "low_confidence": False,
+                }
+            ],
+            "prosody": [],
+            "prosody_unavailable": [],
+            "interactions": [],
+            "segment_interactions": [],
+            "dominant_speaker_limitation": True,
+        }
+        meeting_id = _write_meeting(meetings_dir, sample_audio, base_metadata, base_transcript, audio_analysis)
+
+        res = await client.get(f"/api/meetings/{meeting_id}/analysis-context")
+        assert res.status_code == 200
+        ctx = res.json()["context"]
+        assert "single speaker dominates" in ctx

--- a/tests/unit/test_analysis_context.py
+++ b/tests/unit/test_analysis_context.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.schemas import (
+    AudioAnalysis,
+    AudioAnalysisStatus,
+    EmotionAnnotation,
+    EmotionCategory,
+    InteractionEvent,
+    InteractionEventType,
+    SegmentInteraction,
+    Transcript,
+    TranscriptSegment,
+)
+from backend.services import analysis_context
+
+
+def _emotion(
+    *,
+    segment_id: str = "seg_0",
+    speaker: str = "SPEAKER_00",
+    start: float = 0.0,
+    end: float = 1.0,
+    primary: EmotionCategory = EmotionCategory.NEUTRAL,
+    confidence: float = 0.9,
+) -> EmotionAnnotation:
+    return EmotionAnnotation(
+        segment_id=segment_id,
+        speaker=speaker,
+        start=start,
+        end=end,
+        primary_emotion=primary,
+        confidence=confidence,
+        emotion_scores={primary.value: confidence},
+        low_confidence=confidence < 0.5,
+    )
+
+
+def _segment(
+    *,
+    seg_id: str = "seg_0",
+    speaker: str = "SPEAKER_00",
+    start: float = 0.0,
+    end: float = 1.0,
+    text: str = "hello",
+) -> TranscriptSegment:
+    return TranscriptSegment(id=seg_id, start=start, end=end, speaker=speaker, text=text)
+
+
+def _completed_audio_analysis(**kwargs) -> AudioAnalysis:
+    defaults = {
+        "status": AudioAnalysisStatus.COMPLETED,
+        "emotion_status": AudioAnalysisStatus.COMPLETED,
+        "prosody_status": AudioAnalysisStatus.COMPLETED,
+        "interaction_status": AudioAnalysisStatus.COMPLETED,
+    }
+    defaults.update(kwargs)
+    return AudioAnalysis(**defaults)
+
+
+class TestRenderOptOut:
+    def test_returns_empty_string_when_audio_analysis_is_none(self):
+        assert analysis_context.render(None, transcript=None) == ""
+
+
+class TestRenderUnavailable:
+    def test_failed_status_returns_brief_unavailability_note(self):
+        aa = AudioAnalysis(status=AudioAnalysisStatus.FAILED, reason="model_load_error")
+        out = analysis_context.render(aa, transcript=None)
+        assert out.startswith("## Audio Analysis Context")
+        assert "unavailable" in out
+        assert "model_load_error" in out
+        assert "### Emotional Patterns" not in out
+
+    def test_unavailable_status_returns_brief_note(self):
+        aa = AudioAnalysis(status=AudioAnalysisStatus.UNAVAILABLE, reason="language_not_supported:fr")
+        out = analysis_context.render(aa, transcript=None)
+        assert "unavailable" in out
+        assert "language_not_supported:fr" in out
+
+    def test_failed_status_without_reason_uses_default(self):
+        aa = AudioAnalysis(status=AudioAnalysisStatus.FAILED)
+        out = analysis_context.render(aa, transcript=None)
+        assert "audio analysis was not produced" in out
+
+
+class TestEmotionalPatterns:
+    def test_predominant_emotion_with_percentage(self):
+        emotions = [
+            _emotion(segment_id="s1", primary=EmotionCategory.ENGAGED, confidence=0.9),
+            _emotion(segment_id="s2", primary=EmotionCategory.ENGAGED, confidence=0.8),
+            _emotion(segment_id="s3", primary=EmotionCategory.NEUTRAL, confidence=0.7),
+        ]
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=None)
+        assert "predominantly engaged (67%)" in out
+
+    def test_uses_speaker_display_name(self):
+        emotions = [_emotion(speaker="SPEAKER_00", primary=EmotionCategory.NEUTRAL)]
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=None, speakers={"SPEAKER_00": "Alice"})
+        assert "Alice" in out
+        assert "SPEAKER_00" not in out
+
+    def test_surfaces_high_confidence_negative_spikes(self):
+        emotions = [
+            _emotion(segment_id="s1", start=10.0, primary=EmotionCategory.ENGAGED, confidence=0.9),
+            _emotion(segment_id="s2", start=754.0, primary=EmotionCategory.FRUSTRATED, confidence=0.95),
+        ]
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=None)
+        assert "frustrated at 12:34" in out
+
+    def test_does_not_surface_low_confidence_spikes(self):
+        emotions = [
+            _emotion(segment_id="s1", primary=EmotionCategory.ENGAGED, confidence=0.9),
+            _emotion(segment_id="s2", start=60.0, primary=EmotionCategory.FRUSTRATED, confidence=0.4),
+        ]
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=None)
+        assert "spikes" not in out
+
+
+class TestWordToneMismatches:
+    def test_detects_agreement_phrase_with_frustrated_tone(self):
+        emotions = [
+            _emotion(
+                segment_id="s1",
+                speaker="SPEAKER_00",
+                start=15.23,
+                primary=EmotionCategory.FRUSTRATED,
+                confidence=0.78,
+            )
+        ]
+        transcript = Transcript(
+            segments=[_segment(seg_id="s1", speaker="SPEAKER_00", start=15.23, text="That works for me.")]
+        )
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=transcript)
+        assert "### Word-Tone Mismatches" in out
+        assert "tone indicates frustrated" in out
+        assert "0.78" in out
+        assert "That works for me." in out
+
+    def test_hedges_low_confidence_mismatch(self):
+        emotions = [
+            _emotion(
+                segment_id="s1",
+                primary=EmotionCategory.UNCERTAIN,
+                confidence=0.42,
+            )
+        ]
+        transcript = Transcript(segments=[_segment(seg_id="s1", text="No concerns here.")])
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=transcript)
+        assert "tone may indicate uncertain" in out
+        assert "tone indicates" not in out
+
+    def test_no_mismatch_when_text_does_not_signal_agreement(self):
+        emotions = [_emotion(segment_id="s1", primary=EmotionCategory.FRUSTRATED, confidence=0.9)]
+        transcript = Transcript(segments=[_segment(seg_id="s1", text="The deadline is impossible.")])
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=transcript)
+        assert "### Word-Tone Mismatches" not in out
+
+    def test_no_mismatch_when_emotion_is_neutral(self):
+        emotions = [_emotion(segment_id="s1", primary=EmotionCategory.NEUTRAL, confidence=0.9)]
+        transcript = Transcript(segments=[_segment(seg_id="s1", text="That works for me.")])
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=transcript)
+        assert "### Word-Tone Mismatches" not in out
+
+
+class TestInteractionDynamics:
+    def test_counts_interruptions_per_pair(self):
+        events = [
+            InteractionEvent(
+                event_type=InteractionEventType.INTERRUPTION,
+                timestamp=10.0,
+                speaker_a="SPEAKER_01",
+                speaker_b="SPEAKER_00",
+                duration=0.4,
+            ),
+            InteractionEvent(
+                event_type=InteractionEventType.INTERRUPTION,
+                timestamp=22.0,
+                speaker_a="SPEAKER_01",
+                speaker_b="SPEAKER_00",
+                duration=0.5,
+            ),
+        ]
+        aa = _completed_audio_analysis(interactions=events)
+        out = analysis_context.render(aa, transcript=None)
+        assert "### Interaction Dynamics" in out
+        assert "SPEAKER_00 interrupted SPEAKER_01 2 times (reverse: 0)" in out
+
+    def test_emits_average_response_latency_per_speaker(self):
+        segment_interactions = [
+            SegmentInteraction(segment_id="s1", hesitation_before=0.4),
+            SegmentInteraction(segment_id="s2", hesitation_before=2.0),
+        ]
+        transcript = Transcript(
+            segments=[
+                _segment(seg_id="s1", speaker="SPEAKER_00"),
+                _segment(seg_id="s2", speaker="SPEAKER_01"),
+            ]
+        )
+        aa = _completed_audio_analysis(segment_interactions=segment_interactions)
+        out = analysis_context.render(aa, transcript=transcript)
+        assert "Average response latency:" in out
+        assert "SPEAKER_00 (0.4s)" in out
+        assert "SPEAKER_01 (2.0s)" in out
+
+    def test_dominant_speaker_limitation_appends_disclosure(self):
+        emotions = [_emotion(primary=EmotionCategory.ENGAGED)]
+        aa = _completed_audio_analysis(emotions=emotions, dominant_speaker_limitation=True)
+        out = analysis_context.render(aa, transcript=None)
+        assert "single speaker dominates" in out
+
+    def test_dominance_alone_renders_interaction_section(self):
+        # No interactions but the limitation flag is set — section should still appear.
+        aa = _completed_audio_analysis(dominant_speaker_limitation=True)
+        out = analysis_context.render(aa, transcript=None)
+        assert "### Interaction Dynamics" in out
+        assert "single speaker dominates" in out
+
+
+class TestEnergyTrajectory:
+    def test_reports_peak_and_trough_windows(self):
+        emotions = [
+            _emotion(segment_id="s1", start=30.0, end=60.0, primary=EmotionCategory.ENGAGED, confidence=0.9),
+            _emotion(
+                segment_id="s2",
+                start=2200.0,
+                end=2230.0,
+                primary=EmotionCategory.DISENGAGED,
+                confidence=0.85,
+            ),
+        ]
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=None)
+        assert "### Energy Trajectory" in out
+        assert "peaked" in out
+        assert "lowest" in out
+
+    def test_single_window_does_not_emit_separate_trough(self):
+        emotions = [_emotion(segment_id="s1", start=10.0, primary=EmotionCategory.ENGAGED, confidence=0.9)]
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=None)
+        assert "peaked" in out
+        assert "lowest" not in out
+
+
+class TestInstructions:
+    def test_completed_render_includes_audio_analysis_instructions(self):
+        emotions = [_emotion(primary=EmotionCategory.NEUTRAL, confidence=0.9)]
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=None)
+        assert "## Audio Analysis Instructions" in out
+        assert "Hidden disagreements" in out
+        assert "Contribution quality" in out
+        assert "Psychological safety" in out
+        assert "Meeting effectiveness" in out
+
+    def test_unavailable_render_omits_instructions(self):
+        aa = AudioAnalysis(status=AudioAnalysisStatus.FAILED, reason="oops")
+        out = analysis_context.render(aa, transcript=None)
+        assert "## Audio Analysis Instructions" not in out
+
+    def test_completed_with_no_data_falls_back_to_unavailability(self):
+        # COMPLETED status but every list is empty — there is nothing to surface.
+        aa = _completed_audio_analysis()
+        out = analysis_context.render(aa, transcript=None)
+        assert "unavailable" in out
+        assert "## Audio Analysis Instructions" not in out
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "That works for me.",
+        "Yeah, sounds good.",
+        "No concerns here.",
+        "Agreed.",
+        "I'm fine with that.",
+        "Looks good.",
+    ],
+)
+def test_agreement_phrase_lexicon_matches_common_acceptance_language(phrase):
+    emotions = [_emotion(segment_id="s1", primary=EmotionCategory.FRUSTRATED, confidence=0.8)]
+    transcript = Transcript(segments=[_segment(seg_id="s1", text=phrase)])
+    aa = _completed_audio_analysis(emotions=emotions)
+    out = analysis_context.render(aa, transcript=transcript)
+    assert "### Word-Tone Mismatches" in out

--- a/tests/unit/test_analysis_context.py
+++ b/tests/unit/test_analysis_context.py
@@ -9,6 +9,7 @@ from backend.schemas import (
     EmotionCategory,
     InteractionEvent,
     InteractionEventType,
+    ProsodyUnavailable,
     SegmentInteraction,
     Transcript,
     TranscriptSegment,
@@ -250,6 +251,27 @@ class TestEnergyTrajectory:
         out = analysis_context.render(aa, transcript=None)
         assert "peaked" in out
         assert "lowest" not in out
+
+
+class TestDataLimitations:
+    def test_excluded_non_speech_segments_disclosed(self):
+        emotions = [_emotion(primary=EmotionCategory.ENGAGED, confidence=0.9)]
+        prosody_unavailable = [
+            ProsodyUnavailable(segment_id="s1", reason="non_speech"),
+            ProsodyUnavailable(segment_id="s2", reason="non_speech"),
+            ProsodyUnavailable(segment_id="s3", reason="too_short"),
+        ]
+        aa = _completed_audio_analysis(emotions=emotions, prosody_unavailable=prosody_unavailable)
+        out = analysis_context.render(aa, transcript=None)
+        assert "### Data Limitations" in out
+        assert "3 segments excluded" in out
+        assert "non_speech" in out
+
+    def test_no_limitations_section_when_prosody_unavailable_empty(self):
+        emotions = [_emotion(primary=EmotionCategory.ENGAGED, confidence=0.9)]
+        aa = _completed_audio_analysis(emotions=emotions)
+        out = analysis_context.render(aa, transcript=None)
+        assert "### Data Limitations" not in out
 
 
 class TestInstructions:


### PR DESCRIPTION
Closes https://github.com/nimblehq/audio-transcriber/issues/52

## Summary

Closes the loop on the audio-emotional-intelligence pipeline (#49 / #50 / #51): when a user opens the Analysis tab on a meeting that opted into audio analysis, the generated prompt now includes a dedicated **Audio Analysis Context** section so the LLM can reason about hidden disagreements, contribution quality, psychological safety, and meeting effectiveness.

The context section surfaces:

- per-speaker emotional patterns with timestamps for high-confidence frustrated/uncertain spikes,
- word-tone mismatches (agreement-language phrases said with frustrated or uncertain tone), hedged when emotion confidence is below 0.5,
- interaction dynamics: interruption pairs, average response latency, notable hesitations, and a single-speaker-dominance disclosure when applicable,
- a 5-minute-window energy trajectory (peak / trough),
- template-agnostic LLM instructions for weighting these signals.

For meetings opted out of audio analysis, the generated prompt is byte-identical to the pre-feature output (BR-4.4).

## Approach

Server-side context generation. The audio analysis JSON is large (~1MB on real meetings), and the heuristics for word-tone mismatch detection, hedging, and energy aggregation are non-trivial — keeping them in Python keeps the wire payload small and makes the logic unit-testable.

- New service `backend/services/analysis_context.py` renders the markdown context block from a meeting's `AudioAnalysis` data.
- New endpoint `GET /api/meetings/{id}/analysis-context` returns `{"context": "<markdown>"}` — empty string when opted out, brief unavailability note when audio analysis was attempted but produced no usable output, full block otherwise.
- Each analysis template (interview / sales / client / other) gets a single `[AUDIO ANALYSIS CONTEXT]` placeholder before the transcript section. The frontend strips the placeholder line entirely when context is empty, preserving byte-identical output for opted-out meetings.
- The prototype-scope template is intentionally not modified — it's a product-scoping prompt, audio context isn't relevant.

## Verification

- 33 new tests added: 27 unit (`tests/unit/test_analysis_context.py`) covering each helper independently, 6 integration (`tests/integration/test_analysis_context.py`) covering the endpoint across opted-out, opted-in-no-data, opted-in-failed, opted-in-completed, and dominant-speaker scenarios.
- Full suite: 255 passed.
- ruff check + ruff format: clean.
- Architect review: no critical or major convention issues.
- BR-4.4 verified by inspection of the post-strip template against the pre-feature template — byte-identical.