### PR TITLE
[#53] Surface audio insights inline on transcript and in new Overview tab

### DIFF
--- a/.argus/plans/52-audio-analysis-context.md
+++ b/.argus/plans/52-audio-analysis-context.md
@@ -1,0 +1,36 @@
+# Plan — #52 Audio Analysis Context in Analysis Prompts
+
+## Approach
+
+Server-side context generation. New endpoint `GET /api/meetings/{id}/analysis-context` returns the rendered Audio Analysis Context markdown (empty string when opted out → byte-identical prompt to today's, satisfying BR-4.4).
+
+Frontend fetches the context alongside the template and substitutes a `[AUDIO ANALYSIS CONTEXT]` placeholder.
+
+## Files
+
+- `backend/services/analysis_context.py` (new) — pure functions assembling the context markdown.
+- `backend/routers/analysis.py` — add endpoint.
+- `templates/{interview,sales,client,other}_analysis.md` (`other.md`) — add placeholder before `## Transcript`. Skip `prototype_scope.md`.
+- `frontend/js/api.js` — `getAnalysisContext`.
+- `frontend/js/components/analysis-viewer.js` — fetch + substitute.
+- `tests/unit/test_analysis_context.py` (new).
+- `tests/integration/test_analysis_context.py` (new).
+
+## Heuristics
+
+- **Word-tone mismatch:** transcript text matches a small positive-agreement lexicon (`works for me`, `sounds good`, `that's fine`, `no concerns`, `agreed`, `sure thing`, `fine by me`, `okay`) AND emotion is `frustrated`/`uncertain` with confidence ≥ 0.5. Confidence < 0.5 → hedged ("may indicate"); ≥ 0.5 → asserted ("indicates").
+- **Emotional spikes:** per-speaker, list timestamps where emotion is `frustrated` or `uncertain` with confidence ≥ 0.7.
+- **Energy trajectory:** 5-minute windows. Score per segment: engaged/confident = +1 × confidence, disengaged/frustrated = -1 × confidence, neutral/uncertain = 0. Surface peak window and trough window.
+- **Hedging:** below 0.5 confidence triggers "possibly", "may indicate".
+- **Single-speaker dominance:** if `dominant_speaker_limitation` true, append explicit note in Interaction Dynamics section.
+
+## Commits
+
+1. service + unit tests
+2. endpoint + integration tests
+3. template placeholder updates
+4. frontend wiring
+
+## Mode
+
+Standard (test-alongside, not strict TDD). Heuristics are tunable.

--- a/.argus/plans/53-audio-insights-ui.md
+++ b/.argus/plans/53-audio-insights-ui.md
@@ -1,0 +1,21 @@
+# Plan — Story #53: Audio insights in transcript viewer + Overview tab
+
+## Files
+- Backend: `backend/schemas.py`, `backend/routers/meetings.py`, `tests/integration/test_meetings.py`
+- Frontend: `frontend/js/components/transcript-viewer.js`, `frontend/js/components/overview-viewer.js` (new), `frontend/index.html`, `frontend/css/styles.css`
+
+## Commits
+1. `[#53] Expose audio_analysis in meeting detail API`
+2. `[#53] Render inline emotion, prosody, mismatch, and interaction indicators on transcript segments`
+3. `[#53] Add Overview tab with trajectory chart and interaction summary`
+
+## Decisions
+- Standard mode (not strict TDD): backend gets integration tests; frontend is browser-smoke-tested.
+- Word-tone mismatch detection replicated in JS (mirrors `backend/services/analysis_context.py` AGREEMENT_PHRASES + MISMATCH_EMOTIONS). Acceptable JS↔Py drift risk; revisit if list grows.
+- Prosody summary surfaced via `title` attribute (no custom tooltip popover).
+- Backward compat gate: `audio_analysis_enabled === true` AND `audio_analysis?.status === "completed"`. No try/catch.
+- Overview chart is inline SVG (no dependency) reusing the energy-score logic from backend (positive: engaged/confident, negative: disengaged/frustrated).
+
+## Risks
+- Word-tone mismatch JS↔Py drift if AGREEMENT_PHRASES expands.
+- `title` tooltips have minimal styling control (acceptable).

--- a/backend/routers/meetings.py
+++ b/backend/routers/meetings.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 
 from backend.schemas import (
+    AudioAnalysis,
     JobStatus,
     MeetingDetail,
     MeetingMetadata,
@@ -194,7 +195,13 @@ async def get_meeting(meeting_id: str):
         with open(transcript_path) as f:
             transcript = Transcript(**json.load(f))
 
-    return MeetingDetail(metadata=metadata, transcript=transcript)
+    audio_analysis = None
+    audio_analysis_path = MEETINGS_DIR / meeting_id / "audio_analysis.json"
+    if audio_analysis_path.exists():
+        with open(audio_analysis_path) as f:
+            audio_analysis = AudioAnalysis(**json.load(f))
+
+    return MeetingDetail(metadata=metadata, transcript=transcript, audio_analysis=audio_analysis)
 
 
 @router.patch("/meetings/{meeting_id}", response_model=MeetingMetadata)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -172,6 +172,7 @@ class MeetingSummary(BaseModel):
 class MeetingDetail(BaseModel):
     metadata: MeetingMetadata
     transcript: Transcript | None = None
+    audio_analysis: AudioAnalysis | None = None
 
 
 class JobInfo(BaseModel):

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -687,6 +687,141 @@ body {
     cursor: help;
 }
 
+/* Overview tab */
+.overview-view {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.overview-section {
+    background: var(--bg-surface);
+    border-radius: var(--radius);
+    padding: 16px 20px;
+}
+
+.overview-heading {
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+}
+
+.overview-empty {
+    text-align: center;
+    padding: 48px 20px;
+    color: var(--text-muted);
+}
+
+.overview-empty p {
+    margin-bottom: 8px;
+}
+
+.overview-empty-hint {
+    font-size: 13px;
+}
+
+.overview-empty a {
+    color: var(--primary);
+    text-decoration: none;
+}
+
+.overview-empty a:hover {
+    text-decoration: underline;
+}
+
+.overview-notice {
+    background: var(--bg-surface);
+    border-left: 3px solid var(--warning);
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.overview-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.overview-list li {
+    font-size: 14px;
+    color: var(--text);
+}
+
+.overview-muted {
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.trajectory-chart svg {
+    width: 100%;
+    height: 160px;
+    display: block;
+}
+
+.trajectory-baseline {
+    stroke: var(--border);
+    stroke-width: 1;
+    stroke-dasharray: 3 3;
+}
+
+.trajectory-line {
+    stroke: var(--primary);
+    stroke-width: 2;
+}
+
+.trajectory-point {
+    fill: var(--primary);
+    stroke: var(--bg-surface);
+    stroke-width: 2;
+    cursor: pointer;
+    transition: r 0.15s;
+}
+
+.trajectory-point:hover,
+.trajectory-point:focus {
+    r: 7;
+    outline: none;
+}
+
+.trajectory-label {
+    fill: var(--text-muted);
+    font-size: 10px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.trajectory-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-top: 8px;
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.trajectory-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.legend-swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.legend-positive { background: var(--success); }
+.legend-negative { background: var(--danger); }
+
 /* Speaker Editor Popover */
 .speaker-popover {
     position: absolute;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -785,6 +785,10 @@ body {
     transition: r 0.15s;
 }
 
+.trajectory-point-positive { fill: var(--success); }
+.trajectory-point-negative { fill: var(--danger); }
+.trajectory-point-neutral { fill: var(--text-muted); }
+
 .trajectory-point:hover,
 .trajectory-point:focus {
     r: 7;
@@ -821,6 +825,7 @@ body {
 
 .legend-positive { background: var(--success); }
 .legend-negative { background: var(--danger); }
+.legend-neutral { background: var(--text-muted); }
 
 /* Speaker Editor Popover */
 .speaker-popover {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -755,6 +755,57 @@ body {
     color: var(--text);
 }
 
+.overview-list-compact {
+    margin-top: 8px;
+    gap: 4px;
+}
+
+.overview-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 8px;
+    font-size: 14px;
+}
+
+.overview-table th,
+.overview-table td {
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+}
+
+.overview-table th {
+    color: var(--text-muted);
+    font-weight: 500;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.overview-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.overview-num {
+    text-align: right !important;
+    font-variant-numeric: tabular-nums;
+}
+
+.overview-details {
+    margin-top: 12px;
+}
+
+.overview-details summary {
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 13px;
+    padding: 4px 0;
+}
+
+.overview-details summary:hover {
+    color: var(--text);
+}
+
 .overview-muted {
     color: var(--text-muted);
     font-size: 13px;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -600,6 +600,93 @@ body {
     padding-left: 2px;
 }
 
+/* Audio analysis indicators (emotion, prosody, mismatch, interaction) */
+.segment-insights {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.emotion-badge {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 500;
+    background: var(--bg-active);
+    color: var(--text);
+    border: 1px solid var(--border);
+    white-space: nowrap;
+}
+
+.emotion-confident { background: #1e3a5c; color: #8ec5ff; border-color: #2a5a9c; }
+.emotion-engaged { background: #1f3d2a; color: #8de4a4; border-color: #2a6e3a; }
+.emotion-neutral { background: var(--bg-active); color: var(--text-muted); border-color: var(--border); }
+.emotion-uncertain { background: #3d3a1f; color: #f0d97a; border-color: #6e6a2a; }
+.emotion-frustrated { background: #3d1f1f; color: #f08a8a; border-color: #6e2a2a; }
+.emotion-disengaged { background: #2a2a2a; color: #a0a0a0; border-color: #404040; }
+
+[data-theme="light"] .emotion-confident { background: #dbe8f8; color: #2a5a9c; border-color: #b8d0ec; }
+[data-theme="light"] .emotion-engaged { background: #dcf5e0; color: #2a7a3a; border-color: #b8e6c4; }
+[data-theme="light"] .emotion-neutral { background: #ececec; color: #6e6e73; border-color: #d1d1d6; }
+[data-theme="light"] .emotion-uncertain { background: #f6efd0; color: #8a6e1a; border-color: #e0d59a; }
+[data-theme="light"] .emotion-frustrated { background: #fde0e0; color: #a02a2a; border-color: #f0bcbc; }
+[data-theme="light"] .emotion-disengaged { background: #ebebeb; color: #888; border-color: #d4d4d4; }
+
+.emotion-badge-muted {
+    opacity: 0.55;
+    font-style: italic;
+}
+
+.prosody-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--bg-active);
+    color: var(--text-muted);
+    font-size: 11px;
+    cursor: help;
+    border: 1px solid var(--border);
+}
+
+.mismatch-marker {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 1px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+    background: transparent;
+    color: var(--warning);
+    border: 1px solid var(--warning);
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.mismatch-marker:hover {
+    background: var(--warning);
+    color: var(--bg);
+}
+
+.interaction-marker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--primary);
+    border: 1px solid var(--primary);
+    font-size: 12px;
+    cursor: help;
+}
+
 /* Speaker Editor Popover */
 .speaker-popover {
     position: absolute;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,6 +38,7 @@
     <script src="/static/js/components/meeting-list.js"></script>
     <script src="/static/js/components/upload.js"></script>
     <script src="/static/js/components/transcript-viewer.js"></script>
+    <script src="/static/js/components/overview-viewer.js"></script>
     <script src="/static/js/components/speaker-editor.js"></script>
     <script src="/static/js/components/analysis-viewer.js"></script>
     <script src="/static/js/app.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,7 @@
 
     <script src="/static/js/utils.js"></script>
     <script src="/static/js/api.js"></script>
+    <script src="/static/js/components/audio-insights.js"></script>
     <script src="/static/js/components/meeting-list.js"></script>
     <script src="/static/js/components/upload.js"></script>
     <script src="/static/js/components/transcript-viewer.js"></script>

--- a/frontend/js/components/audio-insights.js
+++ b/frontend/js/components/audio-insights.js
@@ -1,0 +1,115 @@
+/* Shared helpers for rendering audio analysis insights.
+ * Mirrors a subset of backend/services/analysis_context.py — keep the
+ * agreement phrases and mismatch emotions in sync with the Python file.
+ */
+
+const AudioInsights = (() => {
+    const AGREEMENT_PHRASES = [
+        'works for me', 'sounds good', "that's fine", 'thats fine',
+        'no concerns', 'no issues', 'no problem', 'i agree', 'agreed',
+        'sure thing', 'fine by me', 'looks good', 'all good',
+        'happy with that', "i'm good", 'im good', 'makes sense',
+        "i'm okay with", 'im okay with', "i'm fine with", 'im fine with',
+    ];
+
+    const MISMATCH_EMOTIONS = new Set(['frustrated', 'uncertain']);
+    const ENERGY_POSITIVE = new Set(['engaged', 'confident']);
+    const ENERGY_NEGATIVE = new Set(['disengaged', 'frustrated']);
+    const ENERGY_WINDOW_SECONDS = 300;
+
+    const EMOTION_LABELS = {
+        neutral: 'Neutral',
+        confident: 'Confident',
+        frustrated: 'Frustrated',
+        uncertain: 'Uncertain',
+        engaged: 'Engaged',
+        disengaged: 'Disengaged',
+    };
+
+    function hasCompletedAnalysis(meta, audioAnalysis) {
+        return Boolean(meta && meta.audio_analysis_enabled && audioAnalysis && audioAnalysis.status === 'completed');
+    }
+
+    function indexBySegment(audioAnalysis) {
+        const map = {};
+        if (!audioAnalysis) return map;
+        const ensure = (id) => (map[id] = map[id] || { emotion: null, prosody: null, interaction: null });
+        (audioAnalysis.emotions || []).forEach(e => { ensure(e.segment_id).emotion = e; });
+        (audioAnalysis.prosody || []).forEach(p => { ensure(p.segment_id).prosody = p; });
+        (audioAnalysis.segment_interactions || []).forEach(s => { ensure(s.segment_id).interaction = s; });
+        return map;
+    }
+
+    function isWordToneMismatch(emotion, segmentText) {
+        if (!emotion || !MISMATCH_EMOTIONS.has(emotion.primary_emotion)) return false;
+        const lower = (segmentText || '').toLowerCase();
+        return AGREEMENT_PHRASES.some(p => lower.includes(p));
+    }
+
+    function formatProsodyTooltip(prosody) {
+        if (!prosody) return '';
+        const fmt = (n, d = 2) => (Number.isFinite(n) ? n.toFixed(d) : '–');
+        return [
+            `Volume: ${fmt(prosody.volume_mean)} (var ${fmt(prosody.volume_variance)})`,
+            `Pitch: ${fmt(prosody.pitch_mean, 0)} Hz (var ${fmt(prosody.pitch_variance, 0)})`,
+            `Speaking rate: ${fmt(prosody.speaking_rate, 0)} wpm`,
+            `Pause ratio: ${fmt(prosody.pause_ratio)}`,
+        ].join('\n');
+    }
+
+    function hasInteractionMarker(interaction) {
+        if (!interaction) return false;
+        return Boolean(interaction.preceded_by_interruption) || (interaction.hesitation_before || 0) > 0;
+    }
+
+    function interactionTooltip(interaction) {
+        const parts = [];
+        if (interaction.preceded_by_interruption) parts.push('Preceded by an interruption');
+        if (interaction.followed_by_interruption) parts.push('Followed by an interruption');
+        if ((interaction.hesitation_before || 0) > 0) {
+            parts.push(`Hesitated ${interaction.hesitation_before.toFixed(1)}s before speaking`);
+        }
+        return parts.join('\n');
+    }
+
+    function energyScore(emotion) {
+        if (!emotion) return 0;
+        if (ENERGY_POSITIVE.has(emotion.primary_emotion)) return emotion.confidence;
+        if (ENERGY_NEGATIVE.has(emotion.primary_emotion)) return -emotion.confidence;
+        return 0;
+    }
+
+    function buildEnergyTrajectory(emotions) {
+        if (!emotions || emotions.length === 0) return [];
+        const end = Math.max(...emotions.map(e => e.end));
+        if (end <= 0) return [];
+        const nWindows = Math.max(1, Math.floor(end / ENERGY_WINDOW_SECONDS) + 1);
+        const buckets = Array.from({ length: nWindows }, () => []);
+        emotions.forEach(e => {
+            const idx = Math.min(Math.floor(e.start / ENERGY_WINDOW_SECONDS), nWindows - 1);
+            buckets[idx].push(energyScore(e));
+        });
+        return buckets.map((scores, i) => ({
+            index: i,
+            start: i * ENERGY_WINDOW_SECONDS,
+            end: (i + 1) * ENERGY_WINDOW_SECONDS,
+            score: scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : null,
+            count: scores.length,
+        }));
+    }
+
+    return {
+        AGREEMENT_PHRASES,
+        MISMATCH_EMOTIONS,
+        EMOTION_LABELS,
+        ENERGY_WINDOW_SECONDS,
+        hasCompletedAnalysis,
+        indexBySegment,
+        isWordToneMismatch,
+        formatProsodyTooltip,
+        hasInteractionMarker,
+        interactionTooltip,
+        energyScore,
+        buildEnergyTrajectory,
+    };
+})();

--- a/frontend/js/components/overview-viewer.js
+++ b/frontend/js/components/overview-viewer.js
@@ -146,45 +146,90 @@ function wireTrajectorySeek(container) {
 
 function summarizeInterruptions(interactions, meta) {
     const speakers = (meta && meta.speakers) || {};
-    const counts = {};
+    const pairCounts = {};
+    const made = {};
+    const received = {};
+    let total = 0;
+
     interactions
         .filter(e => e.event_type === 'interruption')
         .forEach(e => {
             const key = `${e.speaker_b}|${e.speaker_a}`;
-            counts[key] = (counts[key] || 0) + 1;
+            pairCounts[key] = (pairCounts[key] || 0) + 1;
+            made[e.speaker_b] = (made[e.speaker_b] || 0) + 1;
+            received[e.speaker_a] = (received[e.speaker_a] || 0) + 1;
+            total += 1;
         });
 
-    const pairs = Object.entries(counts).map(([key, count]) => {
+    const speakerIds = new Set([...Object.keys(made), ...Object.keys(received)]);
+    const totals = [...speakerIds].map(id => ({
+        speakerId: id,
+        name: speakers[id] || id,
+        made: made[id] || 0,
+        received: received[id] || 0,
+    }));
+    totals.sort((a, b) => (b.made + b.received) - (a.made + a.received));
+
+    const pairs = Object.entries(pairCounts).map(([key, count]) => {
         const [interrupter, interrupted] = key.split('|');
-        const reverseKey = `${interrupted}|${interrupter}`;
         return {
             interrupter,
             interrupted,
             interrupterName: speakers[interrupter] || interrupter,
             interruptedName: speakers[interrupted] || interrupted,
             count,
-            reverse: counts[reverseKey] || 0,
         };
     });
     pairs.sort((a, b) => b.count - a.count);
-    return pairs;
+
+    return { total, totals, pairs };
 }
 
-function renderInterruptionSummary(pairs) {
-    if (pairs.length === 0) {
+function renderInterruptionSummary({ total, totals, pairs }) {
+    if (total === 0) {
         return '<p class="overview-muted">No interruptions detected.</p>';
     }
+
+    const totalsRows = totals.map(t => `
+        <tr>
+            <td>${escapeHtml(t.name)}</td>
+            <td class="overview-num">${t.made}</td>
+            <td class="overview-num">${t.received}</td>
+        </tr>
+    `).join('');
+
+    const pairLines = pairs.slice(0, 6).map(p => `
+        <li>
+            <strong>${escapeHtml(p.interrupterName)}</strong>
+            <span class="overview-muted"> → </span>
+            <strong>${escapeHtml(p.interruptedName)}</strong>
+            <span class="overview-muted">: ${p.count} time${p.count === 1 ? '' : 's'}</span>
+        </li>
+    `).join('');
+
+    const more = pairs.length > 6 ? `<li class="overview-muted">+${pairs.length - 6} more pair${pairs.length - 6 === 1 ? '' : 's'}</li>` : '';
+
     return `
-        <ul class="overview-list">
-            ${pairs.map(p => `
-                <li>
-                    <strong>${escapeHtml(p.interrupterName)}</strong> interrupted
-                    <strong>${escapeHtml(p.interruptedName)}</strong>
-                    ${p.count} time${p.count === 1 ? '' : 's'}
-                    <span class="overview-muted">(reverse: ${p.reverse})</span>
-                </li>
-            `).join('')}
-        </ul>
+        <p class="overview-muted">${total} interruption${total === 1 ? '' : 's'} total</p>
+        <table class="overview-table">
+            <thead>
+                <tr>
+                    <th>Speaker</th>
+                    <th class="overview-num">Interruptions made</th>
+                    <th class="overview-num">Times interrupted</th>
+                </tr>
+            </thead>
+            <tbody>
+                ${totalsRows}
+            </tbody>
+        </table>
+        <details class="overview-details">
+            <summary>Who interrupted whom (top pairs)</summary>
+            <ul class="overview-list overview-list-compact">
+                ${pairLines}
+                ${more}
+            </ul>
+        </details>
     `;
 }
 

--- a/frontend/js/components/overview-viewer.js
+++ b/frontend/js/components/overview-viewer.js
@@ -90,12 +90,18 @@ function renderTrajectoryChart(trajectory) {
     const baselineY = padY + innerH / 2;
     const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xFor(i).toFixed(1)} ${yFor(p.score).toFixed(1)}`).join(' ');
 
+    const polarityClass = (score) => {
+        if (score > 0.05) return 'trajectory-point-positive';
+        if (score < -0.05) return 'trajectory-point-negative';
+        return 'trajectory-point-neutral';
+    };
+
     const dots = points.map((p, i) => {
         const cx = xFor(i).toFixed(1);
         const cy = yFor(p.score).toFixed(1);
         const seekTo = p.start;
         const tooltip = `${formatWindow(p.start, p.end)} — energy ${p.score >= 0 ? '+' : ''}${p.score.toFixed(2)} (${p.count} segments)`;
-        return `<circle class="trajectory-point" cx="${cx}" cy="${cy}" r="5" data-seek="${seekTo}" tabindex="0" role="button" aria-label="${escapeHtml(tooltip)}"><title>${escapeHtml(tooltip)}</title></circle>`;
+        return `<circle class="trajectory-point ${polarityClass(p.score)}" cx="${cx}" cy="${cy}" r="5" data-seek="${seekTo}" tabindex="0" role="button" aria-label="${escapeHtml(tooltip)}"><title>${escapeHtml(tooltip)}</title></circle>`;
     }).join('');
 
     const labels = points.map((p, i) => {
@@ -113,6 +119,7 @@ function renderTrajectoryChart(trajectory) {
             </svg>
             <div class="trajectory-legend">
                 <span class="trajectory-legend-item"><span class="legend-swatch legend-positive"></span>Positive: engaged, confident</span>
+                <span class="trajectory-legend-item"><span class="legend-swatch legend-neutral"></span>Neutral</span>
                 <span class="trajectory-legend-item"><span class="legend-swatch legend-negative"></span>Negative: disengaged, frustrated</span>
                 <span class="trajectory-legend-item overview-muted">Click a point to seek</span>
             </div>

--- a/frontend/js/components/overview-viewer.js
+++ b/frontend/js/components/overview-viewer.js
@@ -1,0 +1,236 @@
+/* Overview tab: per-meeting energy/emotion trajectory + interaction summary. */
+
+function renderOverviewTab(container, meeting) {
+    const meta = meeting.metadata || meeting._meta || window._meetingMeta;
+    const audioAnalysis = meeting.audio_analysis || window._meetingAudioAnalysis || null;
+    const transcript = meeting.transcript || null;
+
+    if (!meta || !meta.audio_analysis_enabled) {
+        container.innerHTML = renderOptedOutEmptyState();
+        return;
+    }
+
+    if (!audioAnalysis || audioAnalysis.status !== 'completed') {
+        container.innerHTML = renderUnavailableState(audioAnalysis);
+        return;
+    }
+
+    const trajectory = AudioInsights.buildEnergyTrajectory(audioAnalysis.emotions || []);
+    const interruptions = summarizeInterruptions(audioAnalysis.interactions || [], meta);
+    const latencies = summarizeLatencies(audioAnalysis.segment_interactions || [], transcript, meta);
+
+    container.innerHTML = `
+        <div class="overview-view">
+            ${audioAnalysis.dominant_speaker_limitation ? `
+                <div class="overview-notice">
+                    Limited interaction data: a single speaker dominates this meeting, so interruption and turn-taking
+                    signals are sparse.
+                </div>
+            ` : ''}
+
+            <section class="overview-section">
+                <h3 class="overview-heading">Energy &amp; emotion trajectory</h3>
+                ${renderTrajectoryChart(trajectory)}
+            </section>
+
+            <section class="overview-section">
+                <h3 class="overview-heading">Interruptions</h3>
+                ${renderInterruptionSummary(interruptions)}
+            </section>
+
+            <section class="overview-section">
+                <h3 class="overview-heading">Average response latency</h3>
+                ${renderLatencyTable(latencies)}
+            </section>
+        </div>
+    `;
+
+    wireTrajectorySeek(container);
+}
+
+function renderOptedOutEmptyState() {
+    return `
+        <div class="overview-empty">
+            <p>Audio analysis was not run for this meeting.</p>
+            <p class="overview-empty-hint">
+                To get emotion and interaction insights, opt in to audio analysis on the
+                <a href="#/upload" onclick="App.navigate('/upload'); return false;">upload form</a>
+                when uploading the recording.
+            </p>
+        </div>
+    `;
+}
+
+function renderUnavailableState(audioAnalysis) {
+    const reason = (audioAnalysis && audioAnalysis.reason) || 'audio analysis was not produced for this meeting';
+    return `
+        <div class="overview-empty">
+            <p>Audio analysis is unavailable for this meeting.</p>
+            <p class="overview-empty-hint">${escapeHtml(reason)}</p>
+        </div>
+    `;
+}
+
+function renderTrajectoryChart(trajectory) {
+    const points = trajectory.filter(w => w.score !== null);
+    if (points.length === 0) {
+        return '<p class="overview-muted">No emotion data to chart.</p>';
+    }
+
+    const width = 720;
+    const height = 160;
+    const padX = 32;
+    const padY = 20;
+    const innerW = width - padX * 2;
+    const innerH = height - padY * 2;
+
+    const xFor = (i) => padX + (points.length === 1 ? innerW / 2 : (i / (points.length - 1)) * innerW);
+    const yFor = (score) => padY + innerH / 2 - (score * (innerH / 2));
+
+    const baselineY = padY + innerH / 2;
+    const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xFor(i).toFixed(1)} ${yFor(p.score).toFixed(1)}`).join(' ');
+
+    const dots = points.map((p, i) => {
+        const cx = xFor(i).toFixed(1);
+        const cy = yFor(p.score).toFixed(1);
+        const seekTo = p.start;
+        const tooltip = `${formatWindow(p.start, p.end)} — energy ${p.score >= 0 ? '+' : ''}${p.score.toFixed(2)} (${p.count} segments)`;
+        return `<circle class="trajectory-point" cx="${cx}" cy="${cy}" r="5" data-seek="${seekTo}" tabindex="0" role="button" aria-label="${escapeHtml(tooltip)}"><title>${escapeHtml(tooltip)}</title></circle>`;
+    }).join('');
+
+    const labels = points.map((p, i) => {
+        const x = xFor(i).toFixed(1);
+        return `<text class="trajectory-label" x="${x}" y="${height - 4}" text-anchor="middle">${formatStart(p.start)}</text>`;
+    }).join('');
+
+    return `
+        <div class="trajectory-chart" id="trajectory-chart">
+            <svg viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" role="img" aria-label="Energy and emotion trajectory across the meeting">
+                <line class="trajectory-baseline" x1="${padX}" y1="${baselineY}" x2="${width - padX}" y2="${baselineY}"/>
+                <path class="trajectory-line" d="${linePath}" fill="none"/>
+                ${dots}
+                ${labels}
+            </svg>
+            <div class="trajectory-legend">
+                <span class="trajectory-legend-item"><span class="legend-swatch legend-positive"></span>Positive: engaged, confident</span>
+                <span class="trajectory-legend-item"><span class="legend-swatch legend-negative"></span>Negative: disengaged, frustrated</span>
+                <span class="trajectory-legend-item overview-muted">Click a point to seek</span>
+            </div>
+        </div>
+    `;
+}
+
+function wireTrajectorySeek(container) {
+    container.querySelectorAll('.trajectory-point').forEach(node => {
+        const seekTo = parseFloat(node.dataset.seek);
+        const handler = () => {
+            if (!Number.isFinite(seekTo)) return;
+            playFromSegment(seekTo);
+        };
+        node.addEventListener('click', handler);
+        node.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handler();
+            }
+        });
+    });
+}
+
+function summarizeInterruptions(interactions, meta) {
+    const speakers = (meta && meta.speakers) || {};
+    const counts = {};
+    interactions
+        .filter(e => e.event_type === 'interruption')
+        .forEach(e => {
+            const key = `${e.speaker_b}|${e.speaker_a}`;
+            counts[key] = (counts[key] || 0) + 1;
+        });
+
+    const pairs = Object.entries(counts).map(([key, count]) => {
+        const [interrupter, interrupted] = key.split('|');
+        const reverseKey = `${interrupted}|${interrupter}`;
+        return {
+            interrupter,
+            interrupted,
+            interrupterName: speakers[interrupter] || interrupter,
+            interruptedName: speakers[interrupted] || interrupted,
+            count,
+            reverse: counts[reverseKey] || 0,
+        };
+    });
+    pairs.sort((a, b) => b.count - a.count);
+    return pairs;
+}
+
+function renderInterruptionSummary(pairs) {
+    if (pairs.length === 0) {
+        return '<p class="overview-muted">No interruptions detected.</p>';
+    }
+    return `
+        <ul class="overview-list">
+            ${pairs.map(p => `
+                <li>
+                    <strong>${escapeHtml(p.interrupterName)}</strong> interrupted
+                    <strong>${escapeHtml(p.interruptedName)}</strong>
+                    ${p.count} time${p.count === 1 ? '' : 's'}
+                    <span class="overview-muted">(reverse: ${p.reverse})</span>
+                </li>
+            `).join('')}
+        </ul>
+    `;
+}
+
+function summarizeLatencies(segmentInteractions, transcript, meta) {
+    if (!transcript || !transcript.segments) return [];
+    const segmentsById = {};
+    transcript.segments.forEach(s => { segmentsById[s.id] = s; });
+
+    const speakers = (meta && meta.speakers) || {};
+    const bySpeaker = {};
+    segmentInteractions.forEach(si => {
+        if (!(si.hesitation_before > 0)) return;
+        const seg = segmentsById[si.segment_id];
+        if (!seg) return;
+        if (!bySpeaker[seg.speaker]) bySpeaker[seg.speaker] = [];
+        bySpeaker[seg.speaker].push(si.hesitation_before);
+    });
+
+    return Object.entries(bySpeaker).map(([speakerId, vals]) => ({
+        speakerId,
+        name: speakers[speakerId] || speakerId,
+        average: vals.reduce((a, b) => a + b, 0) / vals.length,
+        count: vals.length,
+    })).sort((a, b) => b.average - a.average);
+}
+
+function renderLatencyTable(latencies) {
+    if (latencies.length === 0) {
+        return '<p class="overview-muted">No measurable response latencies.</p>';
+    }
+    return `
+        <ul class="overview-list">
+            ${latencies.map(l => `
+                <li>
+                    <strong>${escapeHtml(l.name)}</strong>:
+                    ${l.average.toFixed(1)}s
+                    <span class="overview-muted">(${l.count} response${l.count === 1 ? '' : 's'})</span>
+                </li>
+            `).join('')}
+        </ul>
+    `;
+}
+
+function formatStart(seconds) {
+    const m = Math.floor(seconds / 60);
+    return `${String(m).padStart(2, '0')}:00`;
+}
+
+function formatWindow(start, end) {
+    const fmt = (s) => {
+        const m = Math.floor(s / 60);
+        const sec = Math.floor(s % 60);
+        return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+    };
+    return `${fmt(start)}–${fmt(end)}`;
+}

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -114,6 +114,7 @@ async function loadMeetingView(container, meetingId) {
             setupSpeakersSidebar();
             window._meetingAudioAnalysis = audioAnalysis;
             window._meetingMeta = meta;
+            window._meetingTranscript = transcript;
         }
     } catch (err) {
         container.innerHTML = `<div class="error-state">Failed to load meeting: ${escapeHtml(err.message)}</div>`;
@@ -498,6 +499,14 @@ function switchTab(tabName, meetingId, meetingType) {
 
     if (tabName === 'plaintext') {
         renderPlainTextTab(tabEl);
+    }
+
+    if (tabName === 'overview') {
+        renderOverviewTab(tabEl, {
+            metadata: window._meetingMeta,
+            audio_analysis: window._meetingAudioAnalysis,
+            transcript: window._meetingTranscript,
+        });
     }
 
     if (tabName === 'analysis' && !tabEl.dataset.loaded) {

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -15,6 +15,7 @@ async function loadMeetingView(container, meetingId) {
         const meeting = await API.getMeeting(meetingId);
         const meta = meeting.metadata;
         const transcript = meeting.transcript;
+        const audioAnalysis = meeting.audio_analysis || null;
 
         const isProcessing = meta.status === 'processing';
         const isError = meta.status === 'error';
@@ -75,6 +76,7 @@ async function loadMeetingView(container, meetingId) {
 
                     <div class="tabs">
                         <button class="tab tab-active" data-tab="transcript" onclick="switchTab('transcript', '${meetingId}', '${meta.type}')">Transcript</button>
+                        <button class="tab" data-tab="overview" onclick="switchTab('overview', '${meetingId}', '${meta.type}')">Overview</button>
                         <button class="tab" data-tab="plaintext" onclick="switchTab('plaintext', '${meetingId}', '${meta.type}')">Plain Text</button>
                         <button class="tab" data-tab="analysis" onclick="switchTab('analysis', '${meetingId}', '${meta.type}')">Analysis</button>
                         <label class="auto-scroll-toggle">
@@ -84,6 +86,7 @@ async function loadMeetingView(container, meetingId) {
                     </div>
 
                     <div id="transcript-tab" class="tab-content tab-content-active"></div>
+                    <div id="overview-tab" class="tab-content" hidden></div>
                     <div id="plaintext-tab" class="tab-content" hidden></div>
                     <div id="analysis-tab" class="tab-content" hidden></div>
 
@@ -105,10 +108,12 @@ async function loadMeetingView(container, meetingId) {
         if (!isProcessing && !isError && transcript) {
             setupAudioPlayer(meetingId);
             setupContextEditor(meetingId);
-            renderSegments(document.getElementById('transcript-tab'), transcript, meta, meetingId);
+            renderSegments(document.getElementById('transcript-tab'), transcript, meta, meetingId, audioAnalysis);
             setupScrollDetection();
             setupBackToTop();
             setupSpeakersSidebar();
+            window._meetingAudioAnalysis = audioAnalysis;
+            window._meetingMeta = meta;
         }
     } catch (err) {
         container.innerHTML = `<div class="error-state">Failed to load meeting: ${escapeHtml(err.message)}</div>`;
@@ -187,7 +192,7 @@ function setupContextEditor(meetingId) {
     });
 }
 
-function renderSegments(container, transcript, meta, meetingId) {
+function renderSegments(container, transcript, meta, meetingId, audioAnalysis) {
     const speakers = { ...meta.speakers };
     const speakerIds = [];
     const firstSegmentIndex = {};
@@ -203,11 +208,15 @@ function renderSegments(container, transcript, meta, meetingId) {
     // Store speakers data globally so onclick handlers can reference it without inline JSON
     window._speakerEditorState = { speakers, meetingId, speakerIds, speakerColorMap, firstSegmentIndex };
 
+    const showInsights = AudioInsights.hasCompletedAnalysis(meta, audioAnalysis);
+    const insightsBySegment = showInsights ? AudioInsights.indexBySegment(audioAnalysis) : {};
+
     container.innerHTML = `
         <div class="segments" id="segments-container">
             ${transcript.segments.map((seg, i) => {
                 const speakerName = speakers[seg.speaker] || seg.speaker;
                 const color = speakerColorMap[seg.speaker];
+                const insights = showInsights ? renderSegmentInsights(seg, insightsBySegment[seg.id]) : '';
                 return `
                     <div class="segment" id="seg-${i}" data-start="${seg.start}" data-end="${seg.end}" data-segment-id="${escapeHtml(seg.id)}">
                         <div class="segment-header">
@@ -216,6 +225,7 @@ function renderSegments(container, transcript, meta, meetingId) {
                                 onclick="handleSpeakerClick(this, '${seg.speaker}', '${seg.id}')">
                                 ${escapeHtml(speakerName)} ▾
                             </span>
+                            ${insights}
                             <button class="btn btn-icon btn-segment-play" onclick="playFromSegment(${seg.start})" title="Play from here">▶</button>
                         </div>
                         <div class="segment-text">${escapeHtml(seg.text)}</div>
@@ -224,6 +234,43 @@ function renderSegments(container, transcript, meta, meetingId) {
             }).join('')}
         </div>
     `;
+}
+
+function renderSegmentInsights(seg, insights) {
+    if (!insights) return '';
+    const parts = [];
+    const { emotion, prosody, interaction } = insights;
+
+    if (emotion) {
+        const label = AudioInsights.EMOTION_LABELS[emotion.primary_emotion] || emotion.primary_emotion;
+        const muted = emotion.low_confidence ? ' emotion-badge-muted' : '';
+        const tooltip = `Tone: ${label} (confidence ${(emotion.confidence * 100).toFixed(0)}%)`;
+        const hedge = emotion.low_confidence ? '?' : '';
+        parts.push(
+            `<span class="emotion-badge emotion-${emotion.primary_emotion}${muted}" title="${escapeHtml(tooltip)}">${escapeHtml(label)}${hedge}</span>`
+        );
+    }
+
+    if (prosody) {
+        parts.push(
+            `<span class="prosody-indicator" title="${escapeHtml(AudioInsights.formatProsodyTooltip(prosody))}" aria-label="Prosody summary">≈</span>`
+        );
+    }
+
+    if (emotion && AudioInsights.isWordToneMismatch(emotion, seg.text)) {
+        const tooltip = `Words signal agreement but tone reads ${emotion.primary_emotion} (${(emotion.confidence * 100).toFixed(0)}% confidence). Click to seek.`;
+        parts.push(
+            `<button type="button" class="mismatch-marker" title="${escapeHtml(tooltip)}" onclick="playFromSegment(${seg.start})" aria-label="Word-tone mismatch — seek to ${formatTimestamp(seg.start)}">⚠ tone</button>`
+        );
+    }
+
+    if (interaction && AudioInsights.hasInteractionMarker(interaction)) {
+        parts.push(
+            `<span class="interaction-marker" title="${escapeHtml(AudioInsights.interactionTooltip(interaction))}" aria-label="Interaction event">↺</span>`
+        );
+    }
+
+    return parts.length ? `<span class="segment-insights">${parts.join('')}</span>` : '';
 }
 
 function handleSpeakerClick(element, speakerId, segmentId) {

--- a/tests/integration/test_meetings.py
+++ b/tests/integration/test_meetings.py
@@ -197,6 +197,43 @@ class TestGetMeeting:
         res = await client.get("/api/meetings/nonexistent")
         assert res.status_code == 404
 
+    async def test_audio_analysis_absent_when_not_run(self, client, populated_meeting):
+        """A meeting without audio_analysis.json on disk reports audio_analysis=null."""
+        res = await client.get(f"/api/meetings/{populated_meeting}")
+        assert res.status_code == 200
+        assert res.json()["audio_analysis"] is None
+
+    async def test_audio_analysis_returned_when_present(self, client, populated_meeting, meetings_dir: Path):
+        """The audio_analysis.json file on disk is returned in MeetingDetail."""
+        audio_analysis = {
+            "status": "completed",
+            "emotions": [
+                {
+                    "segment_id": "seg-001",
+                    "speaker": "SPEAKER_00",
+                    "start": 0.0,
+                    "end": 5.2,
+                    "primary_emotion": "confident",
+                    "confidence": 0.82,
+                    "emotion_scores": {"confident": 0.82, "neutral": 0.18},
+                    "low_confidence": False,
+                }
+            ],
+            "prosody": [],
+            "interactions": [],
+            "segment_interactions": [],
+            "dominant_speaker_limitation": False,
+        }
+        (meetings_dir / populated_meeting / "audio_analysis.json").write_text(json.dumps(audio_analysis))
+
+        res = await client.get(f"/api/meetings/{populated_meeting}")
+        assert res.status_code == 200
+        data = res.json()["audio_analysis"]
+        assert data is not None
+        assert data["status"] == "completed"
+        assert len(data["emotions"]) == 1
+        assert data["emotions"][0]["primary_emotion"] == "confident"
+
 
 class TestUpdateMeeting:
     async def test_update_title(self, client, populated_meeting):


### PR DESCRIPTION
## Summary

Closes #53. Surfaces the audio analysis produced by stories #49–#52 in the meeting detail view.

- Inline on every transcript segment: emotion badge (muted when low-confidence), prosody summary tooltip, word-tone mismatch marker (click-to-seek), and an interaction indicator when the segment was preceded by an interruption or hesitation.
- New **Overview** tab next to Transcript / Plain Text / Analysis with a vanilla SVG energy/emotion trajectory chart (click a point to seek), an interruption summary (who interrupted whom + counts) and per-speaker average response latency.
- Backward-compatible: meetings without audio analysis (opt-out, failed, or legacy) render the transcript exactly as before; the Overview tab shows a clear empty state pointing to the upload form opt-in.
- Theme-aware: every new color flows from the existing CSS variables, with explicit `[data-theme="light"]` overrides for the six emotion classes.

## Implementation notes

- Backend change is a single optional field on `MeetingDetail` plus reading `audio_analysis.json` from disk in `GET /api/meetings/{id}`. No new endpoint.
- Word-tone mismatch detection in JS mirrors `backend/services/analysis_context.py` (AGREEMENT_PHRASES + MISMATCH_EMOTIONS). Header comment flags the drift risk.
- Single-speaker dominance flag surfaces a notice on the Overview tab (BR-5.5).
- Reuses `playFromSegment(start)` for both mismatch markers and trajectory points (BR-5.4).

## Test plan

- [ ] Open a meeting with `audio_analysis_enabled=true` and `audio_analysis.json` on disk — verify emotion badges, prosody tooltip on hover, mismatch marker on at least one segment if the transcript contains an agreement phrase.
- [ ] Click a mismatch marker — audio player seeks to that segment.
- [ ] Switch to Overview tab — chart renders with one point per 5-minute window; click a point and verify the audio player seeks to that timestamp.
- [ ] Open a meeting with `audio_analysis_enabled=false` — transcript renders unchanged; Overview tab shows the opted-out empty state.
- [ ] Open a meeting with `audio_analysis_enabled=true` but no `audio_analysis.json` (e.g., job still running or failed) — transcript renders without inline indicators; Overview tab shows the unavailable state.
- [ ] Toggle dark/light theme — emotion badges, mismatch marker, trajectory chart all stay readable.
- [ ] `.venv/bin/python -m pytest tests/ -q` — all green (259 passed).
- [ ] `.venv/bin/ruff check backend/ tests/` — green.