### PR TITLE
[#54] Fix dropdown field height and caret alignment

### DIFF
--- a/.argus/plans/54-fix-dropdown-styles.md
+++ b/.argus/plans/54-fix-dropdown-styles.md
@@ -1,0 +1,22 @@
+# Plan: Fix dropdown field styles (#54)
+
+## Problem
+- `<select>` height does not match `<input>` height in `.form-group` rows.
+- Native caret has insufficient right padding / odd alignment.
+
+## Approach
+- Suppress native select chrome via `appearance: none` (+ vendor prefixes).
+- Render a custom SVG chevron through `background-image` with `right 12px center` positioning.
+- Add `padding-right: 36px` to leave room for the chevron.
+- Apply the same treatment to `.player-speed select` (smaller variant) for consistency.
+- Provide a theme-aware chevron color (override under `[data-theme="light"]`).
+
+## Files
+- `frontend/css/styles.css`
+
+## Commits
+- `[#54] Fix dropdown field height and caret alignment`
+
+## Verification
+- Visual check on `/upload` (dark + light themes): select height matches input, caret has clear right padding.
+- Visual check on transcript viewer playback speed dropdown.

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -352,6 +352,21 @@ body {
     color: var(--text);
     font-size: 14px;
     font-family: inherit;
+    line-height: 1.4;
+}
+
+.form-group select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    padding-right: 36px;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%238b8d98' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+}
+
+[data-theme="light"] .form-group select {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%236e6e73' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 }
 
 .form-group input:focus,
@@ -470,12 +485,22 @@ body {
 }
 
 .player-speed select {
-    background: var(--bg);
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: var(--bg);
     border: 1px solid var(--border);
     color: var(--text);
-    padding: 4px 8px;
+    padding: 4px 24px 4px 8px;
     border-radius: var(--radius-sm);
     font-size: 13px;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%238b8d98' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+}
+
+[data-theme="light"] .player-speed select {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%236e6e73' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 }
 
 /* Tabs */


### PR DESCRIPTION
## Summary

Closes #54.

Native `<select>` elements rendered taller than `<input>` because they shared `.form-group`'s padding rule but user agents add their own internal padding for the dropdown caret. The native caret also had insufficient right padding.

## Changes

- Suppress native chrome on `.form-group select` and `.player-speed select` with `appearance: none` (+ vendor prefixes).
- Render a custom SVG chevron via `background-image` (data URI), with a `[data-theme="light"]` override so the caret color tracks `--text-muted` in both themes.
- Add `padding-right` so the chevron has breathing room.
- Add `line-height: 1.4` to the shared input/select/textarea rule so heights match precisely.

All four `<select>` elements in the app are covered: `analysis-type`, `type-select`, `language-select` (form fields) and `speed-select` (player).

## Test plan

- [ ] On `/upload`, the Meeting Type and Language selects match the input/textarea height.
- [ ] Caret has clear right-side padding and looks centered vertically.
- [ ] Switch between dark and light themes — caret color updates.
- [ ] Player speed select on the transcript page renders consistently.