### PR TITLE
[#70] Polish meeting list and transcript viewer UI

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -94,10 +94,90 @@ body {
     color: var(--text);
     padding: 6px 10px;
     border: 1px solid var(--border);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .btn-icon:hover {
     background: var(--bg-hover);
+}
+
+.btn-icon:focus-visible,
+.btn-text:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+}
+
+.btn-icon svg {
+    width: 14px;
+    height: 14px;
+    display: block;
+}
+
+.btn-play svg {
+    width: 12px;
+    height: 12px;
+}
+
+.btn-back {
+    background: none;
+    border: 0;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    margin-right: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.btn-back:hover {
+    background: var(--bg-hover);
+    color: var(--text);
+}
+
+.btn-back:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+}
+
+.btn-outline {
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    padding: 6px 14px;
+    font-weight: 500;
+    transition: color 120ms, border-color 120ms, background-color 120ms;
+}
+
+.btn-outline:hover:not(:disabled) {
+    color: var(--text);
+    border-color: var(--text-muted);
+}
+
+.btn-outline:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+}
+
+.btn-outline-danger {
+    color: var(--danger);
+    border-color: rgba(217, 74, 74, 0.4);
+}
+
+.btn-outline-danger:hover:not(:disabled) {
+    color: var(--danger);
+    background: rgba(217, 74, 74, 0.06);
+    border-color: var(--danger);
+}
+
+[data-theme="light"] .btn-outline-danger {
+    border-color: rgba(212, 52, 52, 0.4);
 }
 
 .btn-large {
@@ -162,6 +242,28 @@ body {
     gap: 8px;
 }
 
+.page-header--meetings {
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 24px;
+}
+
+.page-header--meetings h1 {
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.015em;
+}
+
+.page-eyebrow {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}
+
 /* Badges */
 .badge {
     display: inline-block;
@@ -186,22 +288,37 @@ body {
 .meetings-list {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 4px;
 }
 
 .meeting-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 14px 16px;
+    gap: 16px;
+    width: 100%;
+    padding: 14px 18px;
     background: var(--bg-surface);
+    border: 0;
     border-radius: var(--radius);
     cursor: pointer;
-    transition: background-color 0.15s;
+    color: inherit;
+    font-family: inherit;
+    text-align: left;
+    transition: background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .meeting-row:hover {
     background: var(--bg-hover);
+}
+
+.meeting-row:hover .meeting-title {
+    color: var(--primary);
+}
+
+.meeting-row:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: -2px;
 }
 
 .meeting-info {
@@ -209,30 +326,97 @@ body {
     flex-direction: column;
     gap: 4px;
     min-width: 0;
+    flex: 1;
 }
 
 .meeting-title {
+    font-size: 15px;
     font-weight: 500;
+    line-height: 1.35;
+    color: var(--text);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    transition: color 140ms;
 }
 
 .meeting-meta {
     display: flex;
     align-items: center;
-    gap: 12px;
-    font-size: 13px;
+    gap: 10px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
     color: var(--text-muted);
 }
 
-.meeting-status {
-    font-size: 13px;
-    text-transform: capitalize;
-    display: flex;
+.meta-sep {
+    opacity: 0.5;
+}
+
+.meta-pill {
+    display: inline-flex;
     align-items: center;
     gap: 6px;
+    padding: 1px 0;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
 }
+
+.meta-pill::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    flex-shrink: 0;
+}
+
+.meta-pill-other     { color: #d4d48a; }
+.meta-pill-client    { color: #7ae488; }
+.meta-pill-interview { color: #7aa8e4; }
+.meta-pill-sales     { color: #d48ae4; }
+
+[data-theme="light"] .meta-pill-other     { color: #7a7a2a; }
+[data-theme="light"] .meta-pill-client    { color: #2a7a3a; }
+[data-theme="light"] .meta-pill-interview { color: #2a5a9c; }
+[data-theme="light"] .meta-pill-sales     { color: #8a3a9c; }
+
+.meeting-duration {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
+    font-weight: 500;
+    letter-spacing: 0;
+    text-transform: none;
+    opacity: 0.85;
+}
+
+.meeting-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: capitalize;
+    flex-shrink: 0;
+}
+
+.meeting-status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    flex-shrink: 0;
+}
+
+.status-ready .meeting-status-dot { background: var(--success); }
+.status-processing .meeting-status-dot { background: var(--warning); }
+.status-error .meeting-status-dot { background: var(--danger); }
 
 .status-ready { color: var(--success); }
 .status-processing { color: var(--warning); }
@@ -438,15 +622,27 @@ body {
 .audio-player {
     background: var(--bg-surface);
     border-radius: var(--radius);
-    padding: 16px 20px;
+    padding: 14px 20px;
     margin-bottom: 20px;
     display: flex;
     align-items: center;
     gap: 16px;
     position: sticky;
-    top: 0;
+    top: 12px;
     z-index: 10;
     box-shadow: 0 2px 8px var(--shadow);
+}
+
+.audio-player .btn-icon {
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    flex-shrink: 0;
+}
+
+.audio-player .btn-icon svg {
+    width: 12px;
+    height: 12px;
 }
 
 .player-controls {
@@ -533,6 +729,12 @@ body {
     border-bottom-color: var(--primary);
 }
 
+.tab:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: -2px;
+    border-radius: 4px 4px 0 0;
+}
+
 .tab-content {
     display: none;
 }
@@ -559,14 +761,21 @@ body {
 .segments {
     display: flex;
     flex-direction: column;
-    gap: 4px;
 }
 
 .segment {
-    padding: 12px 16px;
+    padding: 10px 16px;
     border-radius: var(--radius);
     border-left: 3px solid transparent;
     transition: background-color 0.15s, border-color 0.15s;
+}
+
+.segment + .segment {
+    margin-top: 14px;
+}
+
+.segment + .segment-cont {
+    margin-top: 6px;
 }
 
 .segment:hover {
@@ -593,9 +802,13 @@ body {
 }
 
 .speaker-label {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     padding: 2px 10px;
+    border: 0;
     border-radius: 12px;
+    font-family: inherit;
     font-size: 13px;
     font-weight: 500;
     color: white;
@@ -605,6 +818,17 @@ body {
 
 .speaker-label:hover {
     opacity: 0.8;
+}
+
+.speaker-label:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+}
+
+.speaker-label-chevron {
+    display: block;
+    opacity: 0.85;
+    flex-shrink: 0;
 }
 
 .btn-segment-play {
@@ -621,8 +845,9 @@ body {
 
 .segment-text {
     font-size: 15px;
-    line-height: 1.7;
+    line-height: 1.8;
     padding-left: 2px;
+    max-width: 72ch;
 }
 
 /* Audio analysis indicators (emotion, prosody, mismatch, interaction) */
@@ -666,17 +891,23 @@ body {
 
 .prosody-indicator {
     display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: var(--bg-active);
+    align-items: end;
+    gap: 1.5px;
+    height: 14px;
     color: var(--text-muted);
-    font-size: 11px;
     cursor: help;
-    border: 1px solid var(--border);
 }
+
+.prosody-indicator i {
+    display: block;
+    width: 2px;
+    background: currentColor;
+    border-radius: 1px;
+}
+
+.prosody-indicator i:nth-child(1) { height: 50%; }
+.prosody-indicator i:nth-child(2) { height: 80%; }
+.prosody-indicator i:nth-child(3) { height: 35%; }
 
 .mismatch-marker {
     display: inline-flex;

--- a/frontend/js/components/meeting-list.js
+++ b/frontend/js/components/meeting-list.js
@@ -1,9 +1,12 @@
 function renderMeetingList(container) {
     container.innerHTML = `
-        <div class="page-header">
-            <h1>Meetings</h1>
+        <header class="page-header page-header--meetings">
+            <div>
+                <div class="page-eyebrow">Library</div>
+                <h1>Meetings</h1>
+            </div>
             <button class="btn btn-primary" onclick="App.navigate('/upload')">Upload Recording</button>
-        </div>
+        </header>
         <div id="meetings-list" class="meetings-list">
             <div class="loading">Loading meetings...</div>
         </div>
@@ -27,20 +30,22 @@ async function loadMeetings() {
         }
 
         listEl.innerHTML = meetings.map(m => `
-            <div class="meeting-row" onclick="App.navigate('/meetings/${m.id}')">
+            <button class="meeting-row" type="button" onclick="App.navigate('/meetings/${m.id}')">
                 <div class="meeting-info">
                     <span class="meeting-title">${escapeHtml(m.title)}</span>
                     <span class="meeting-meta">
-                        <span class="badge badge-${m.type}">${m.type}</span>
+                        <span class="meta-pill meta-pill-${m.type}">${escapeHtml(m.type)}</span>
+                        <span class="meta-sep">&middot;</span>
                         <span>${formatDate(m.created_at)}</span>
-                        <span>${formatDuration(m.duration_seconds)}</span>
+                        <span class="meta-sep">&middot;</span>
+                        <span class="meeting-duration">${formatDuration(m.duration_seconds)}</span>
                     </span>
                 </div>
                 <div class="meeting-status status-${m.status}">
-                    ${m.status === 'processing' ? '<span class="spinner-small"></span>' : ''}
-                    ${m.status}
+                    ${m.status === 'processing' ? '<span class="spinner-small"></span>' : '<span class="meeting-status-dot"></span>'}
+                    <span>${escapeHtml(m.status)}</span>
                 </div>
-            </div>
+            </button>
         `).join('');
     } catch (err) {
         listEl.innerHTML = `<div class="error-state">Failed to load meetings: ${escapeHtml(err.message)}</div>`;

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -5,6 +5,9 @@ let userScrolledAway = false;
 let scrollTimeout = null;
 let backToTopHandler = null;
 
+const ICON_PLAY = '<svg viewBox="0 0 12 12" fill="currentColor" stroke="none"><path d="M3 2 L10 6 L3 10 Z"/></svg>';
+const ICON_PAUSE = '<svg viewBox="0 0 12 12" fill="currentColor" stroke="none"><rect x="3" y="2" width="2.5" height="8" rx="0.5"/><rect x="6.5" y="2" width="2.5" height="8" rx="0.5"/></svg>';
+
 function renderTranscriptView(container, meetingId) {
     container.innerHTML = '<div class="loading">Loading meeting...</div>';
     loadMeetingView(container, meetingId);
@@ -23,12 +26,12 @@ async function loadMeetingView(container, meetingId) {
         container.innerHTML = `
             <div class="meeting-view">
                 <div class="page-header">
-                    <button class="btn btn-text" onclick="App.navigate('/')">← Back</button>
+                    <button class="btn-back" onclick="App.navigate('/')" aria-label="Back to meetings"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2 L4 7 L9 12"/></svg></button>
                     <h1 id="meeting-title">${escapeHtml(meta.title)}</h1>
                     <div class="header-actions">
-                        <span class="badge badge-${meta.type}">${meta.type}</span>
-                        ${!isProcessing ? `<button class="btn btn-text" onclick="handleRerunTranscription('${meetingId}')">Re-run</button>` : ''}
-                        <button class="btn btn-text btn-delete" onclick="handleDeleteMeeting('${meetingId}')">Delete</button>
+                        <span class="meta-pill meta-pill-${meta.type}">${escapeHtml(meta.type)}</span>
+                        ${!isProcessing ? `<button class="btn btn-outline" onclick="handleRerunTranscription('${meetingId}')">Re-run</button>` : ''}
+                        <button class="btn btn-outline btn-outline-danger" onclick="handleDeleteMeeting('${meetingId}')">Delete</button>
                     </div>
                 </div>
 
@@ -54,9 +57,9 @@ async function loadMeetingView(container, meetingId) {
                     <div class="audio-player" id="audio-player">
                         <audio id="audio-element" preload="metadata"></audio>
                         <div class="player-controls">
-                            <button class="btn btn-icon" id="skip-back" title="Back 15s">-15s</button>
-                            <button class="btn btn-icon btn-play" id="play-pause" title="Play/Pause">▶</button>
-                            <button class="btn btn-icon" id="skip-forward" title="Forward 15s">+15s</button>
+                            <button class="btn btn-icon" id="skip-back" title="Back 15s" aria-label="Back 15 seconds"><svg viewBox="0 0 12 12" fill="currentColor" stroke="none" aria-hidden="true"><path d="M10 2 L5 6 L10 10 Z M5 2 L0 6 L5 10 Z"/></svg></button>
+                            <button class="btn btn-icon btn-play" id="play-pause" title="Play/Pause" aria-label="Play"><svg viewBox="0 0 12 12" fill="currentColor" stroke="none" aria-hidden="true"><path d="M3 2 L10 6 L3 10 Z"/></svg></button>
+                            <button class="btn btn-icon" id="skip-forward" title="Forward 15s" aria-label="Forward 15 seconds"><svg viewBox="0 0 12 12" fill="currentColor" stroke="none" aria-hidden="true"><path d="M2 2 L7 6 L2 10 Z M7 2 L12 6 L7 10 Z"/></svg></button>
                         </div>
                         <div class="player-seek">
                             <span id="current-time">0:00</span>
@@ -136,10 +139,12 @@ function setupAudioPlayer(meetingId) {
     playPause.addEventListener('click', () => {
         if (audio.paused) {
             audio.play();
-            playPause.textContent = '⏸';
+            playPause.innerHTML = ICON_PAUSE;
+            playPause.setAttribute('aria-label', 'Pause');
         } else {
             audio.pause();
-            playPause.textContent = '▶';
+            playPause.innerHTML = ICON_PLAY;
+            playPause.setAttribute('aria-label', 'Play');
         }
     });
 
@@ -160,7 +165,8 @@ function setupAudioPlayer(meetingId) {
     });
 
     audio.addEventListener('ended', () => {
-        playPause.textContent = '▶';
+        playPause.innerHTML = ICON_PLAY;
+        playPause.setAttribute('aria-label', 'Play');
     });
 
     seekBar.addEventListener('input', () => {
@@ -212,20 +218,23 @@ function renderSegments(container, transcript, meta, meetingId, audioAnalysis) {
     const showInsights = AudioInsights.hasCompletedAnalysis(meta, audioAnalysis);
     const insightsBySegment = showInsights ? AudioInsights.indexBySegment(audioAnalysis) : {};
 
+    let prevSpeaker = null;
     container.innerHTML = `
         <div class="segments" id="segments-container">
             ${transcript.segments.map((seg, i) => {
                 const speakerName = speakers[seg.speaker] || seg.speaker;
                 const color = speakerColorMap[seg.speaker];
                 const insights = showInsights ? renderSegmentInsights(seg, insightsBySegment[seg.id]) : '';
+                const isContinuation = seg.speaker === prevSpeaker;
+                prevSpeaker = seg.speaker;
                 return `
-                    <div class="segment" id="seg-${i}" data-start="${seg.start}" data-end="${seg.end}" data-segment-id="${escapeHtml(seg.id)}">
+                    <div class="segment${isContinuation ? ' segment-cont' : ''}" id="seg-${i}" data-start="${seg.start}" data-end="${seg.end}" data-segment-id="${escapeHtml(seg.id)}">
                         <div class="segment-header">
                             <span class="segment-time">${formatTimestamp(seg.start)}</span>
-                            <span class="speaker-label" style="background-color: ${color}" data-speaker="${seg.speaker}"
+                            <button type="button" class="speaker-label" style="background-color: ${color}" data-speaker="${seg.speaker}"
                                 onclick="handleSpeakerClick(this, '${seg.speaker}', '${seg.id}')">
-                                ${escapeHtml(speakerName)} ▾
-                            </span>
+                                ${escapeHtml(speakerName)}<svg class="speaker-label-chevron" width="8" height="6" viewBox="0 0 8 6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M1 1.5 L4 4.5 L7 1.5"/></svg>
+                            </button>
                             ${insights}
                             <button class="btn btn-icon btn-segment-play" onclick="playFromSegment(${seg.start})" title="Play from here">▶</button>
                         </div>
@@ -254,7 +263,7 @@ function renderSegmentInsights(seg, insights) {
 
     if (prosody) {
         parts.push(
-            `<span class="prosody-indicator" title="${escapeHtml(AudioInsights.formatProsodyTooltip(prosody))}" aria-label="Prosody summary">≈</span>`
+            `<span class="prosody-indicator" title="${escapeHtml(AudioInsights.formatProsodyTooltip(prosody))}" aria-label="Prosody summary"><i></i><i></i><i></i></span>`
         );
     }
 
@@ -425,7 +434,10 @@ function playFromSegment(startTime) {
     currentAudio.currentTime = startTime;
     currentAudio.play();
     const playPause = document.getElementById('play-pause');
-    if (playPause) playPause.textContent = '⏸';
+    if (playPause) {
+        playPause.innerHTML = ICON_PAUSE;
+        playPause.setAttribute('aria-label', 'Pause');
+    }
 }
 
 function highlightCurrentSegment(currentTime) {


### PR DESCRIPTION
Closes #70

## Summary

- Replaces emoji icons (▶ ⏸ ▾ ← ≈) with inline SVG across the audio player, back button, speaker chevron, and prosody indicator
- Redesigns the meeting list with a "Library" eyebrow, colored meta-pills, status dots, and tighter typography; rows are now real `<button>` elements
- Adds `.btn-back`, `.btn-outline`, `.btn-outline-danger` variants and `:focus-visible` outlines on tabs, segment rows, speaker labels, and icon buttons
- Groups consecutive same-speaker segments tighter via a new `.segment-cont` modifier
- Caps segment text at `72ch` and offsets the sticky audio player to `top: 12px`

## Changes

### CSS (`frontend/css/styles.css`)
- New button variants: `.btn-back`, `.btn-outline`, `.btn-outline-danger` (with light-theme overrides)
- `.meeting-row` rewritten for `<button>` semantics with hover/focus states
- New `.meta-pill` (per category) and `.meeting-status-dot` styles
- `.prosody-indicator` is now a 3-bar SVG-driven mark instead of a circled `≈`
- `.segment-cont` tightens spacing between continuation segments

### Meeting list (`frontend/js/components/meeting-list.js`)
- Page header gains a `Library` eyebrow
- Rows are now `<button type="button">` (a11y win — keyboard activation comes for free)
- Category badge replaced with `.meta-pill`; status row gains a `.meeting-status-dot`
- Defensive `escapeHtml` on `m.type` / `m.status`

### Transcript viewer (`frontend/js/components/transcript-viewer.js`)
- All emoji icons replaced with inline SVGs
- `ICON_PLAY` / `ICON_PAUSE` constants lifted to module scope so `playFromSegment` and `setupAudioPlayer` share a single source of truth
- Speaker labels render as `<button>` (was `<span>`) with chevron SVG
- Consecutive same-speaker segments get the `segment-cont` class
- `aria-label`s added to icon-only buttons (back, skip, play/pause)

## Test plan

- [ ] Meeting list renders with eyebrow, meta-pills, status dots; rows are keyboard-focusable and activate on Enter/Space
- [ ] Audio player controls render as SVG with correct `aria-label`; play/pause icon swaps correctly across click, `playFromSegment`, and `ended`
- [ ] Speaker labels open the editor on click
- [ ] Consecutive same-speaker segments visually grouped (no header gap)
- [ ] Re-run / Delete buttons render with the new outline + danger styling
- [ ] Both light and dark themes render correctly

## Follow-ups (out of scope, flagged by review)

- Dead `.btn-delete` CSS rule can be dropped in a cleanup pass
- `.btn-segment-play` and `upload.js` back link still use emoji `▶` / `←` for consistency
- Audio player icon could listen to `play` / `pause` events for fully reactive state