### PR TITLE
[#74] Warn on analysis tab when speakers are unnamed

### DIFF
--- a/docs/plans/74-warn-unnamed-speakers-on-analysis.md
+++ b/docs/plans/74-warn-unnamed-speakers-on-analysis.md
@@ -1,0 +1,49 @@
+# Plan: Warn on Analysis tab when speakers are unnamed
+
+**Story**: #74
+**Spec**: N/A
+**Branch**: feature/74-warn-unnamed-speakers-on-analysis
+**Date**: 2026-05-29
+**Mode**: Standard — small vanilla JS/CSS change; project has no frontend test framework, no need for TDD scaffolding.
+
+## Technical Decisions
+
+### TD-1: Reuse `.overview-notice` CSS class instead of introducing `.analysis-warning`
+- **Context**: The Analysis tab needs a visual banner; `.overview-notice` already provides the exact look (warning-colored left border, surface background, muted text) used by the Overview tab.
+- **Decision**: Reuse `.overview-notice` directly on the Analysis tab banner.
+- **Alternatives considered**: A parallel `.analysis-warning` class — rejected to avoid visual drift between two identical banners (Architect Minor finding).
+
+### TD-2: Read unnamed-speaker info from `window._speakerEditorState`
+- **Context**: The transcript viewer already computes `speakers` and `speakerIds` and stashes them on a global state bag. Re-deriving from the meeting object would duplicate logic.
+- **Decision**: Read `window._speakerEditorState` in `analysis-viewer.js` with an inline comment documenting the dependency on `transcript-viewer.renderSegments()`.
+- **Alternatives considered**: Re-fetching from a `currentMeeting` global — none exists; would require a new global.
+
+### TD-3: Show the warning both before and after Generate Prompt
+- **Context**: After generation the prompt UI replaces the generator UI. Hiding the warning at that point would let users copy the prompt without seeing that it still contains raw `SPEAKER_xx` labels.
+- **Decision**: Render the warning in both `renderAnalysisTab` (initial) and `renderPromptContent` (post-generate).
+- **Alternatives considered**: Hide post-generate — rejected; the warning is more useful precisely when the user is about to copy the prompt.
+
+## Files to Create or Modify
+
+- `frontend/js/components/analysis-viewer.js` — add helpers `getUnnamedSpeakersInfo()` and `renderUnnamedSpeakersWarning()`; prepend the banner in both render functions.
+- `frontend/css/styles.css` — no new class; if a tab-context margin override is needed, add a one-liner.
+
+## Approach per AC
+
+### AC: Warning visible on the Analysis tab when speakers are not labeled
+- On Analysis tab render, count speakers in `window._speakerEditorState.speakerIds` where `isUnidentifiedSpeaker(state.speakers[id] || id)` is true.
+- If `unnamed > 0`, render an `.overview-notice` banner at the top with a sentence explaining the impact and pointing users to the Transcript tab.
+- If `unnamed === 0` or state is missing, render nothing.
+
+## Commit Sequence
+
+1. `[#74] Warn on analysis tab when speakers are unnamed`
+
+## Risks and Trade-offs
+
+- Cross-component read of `window._speakerEditorState` couples `analysis-viewer.js` to `transcript-viewer.js` lifecycle. Mitigated by an inline comment so a future refactor flags the dependency.
+- Persistent warning after Generate Prompt is intentional (see TD-3). Worth a note in the PR description so reviewers don't read it as accidental duplication.
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1241,7 +1241,35 @@ body {
 
 /* Analysis */
 .analysis-warning {
-    margin-bottom: 16px;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 20px;
+    padding: 14px 18px;
+    background: color-mix(in srgb, var(--warning) 18%, var(--bg-surface));
+    border: 1px solid var(--warning);
+    border-left: 4px solid var(--warning);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.analysis-warning-icon {
+    flex: 0 0 auto;
+    font-size: 20px;
+    line-height: 1.2;
+    color: var(--warning);
+}
+
+.analysis-warning-body {
+    flex: 1 1 auto;
+}
+
+.analysis-warning-body strong {
+    display: block;
+    margin-bottom: 2px;
+    color: var(--text);
 }
 
 .analysis-warning code {
@@ -1249,6 +1277,7 @@ body {
     padding: 1px 6px;
     border-radius: 3px;
     font-size: 12px;
+    border: 1px solid var(--border);
 }
 
 .analysis-generator {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1240,6 +1240,17 @@ body {
 }
 
 /* Analysis */
+.analysis-warning {
+    margin-bottom: 16px;
+}
+
+.analysis-warning code {
+    background: var(--bg);
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+
 .analysis-generator {
     text-align: center;
     padding: 40px 20px;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1239,8 +1239,8 @@ body {
     color: var(--text-muted);
 }
 
-/* Analysis */
-.analysis-warning {
+/* Unnamed-speakers warning (shared by Plain Text + Analysis tabs) */
+.unnamed-speakers-warning {
     display: flex;
     align-items: flex-start;
     gap: 12px;
@@ -1255,24 +1255,24 @@ body {
     line-height: 1.5;
 }
 
-.analysis-warning-icon {
+.unnamed-speakers-warning-icon {
     flex: 0 0 auto;
     font-size: 20px;
     line-height: 1.2;
     color: var(--warning);
 }
 
-.analysis-warning-body {
+.unnamed-speakers-warning-body {
     flex: 1 1 auto;
 }
 
-.analysis-warning-body strong {
+.unnamed-speakers-warning-body strong {
     display: block;
     margin-bottom: 2px;
     color: var(--text);
 }
 
-.analysis-warning code {
+.unnamed-speakers-warning code {
     background: var(--bg);
     padding: 1px 6px;
     border-radius: 3px;

--- a/frontend/js/components/analysis-viewer.js
+++ b/frontend/js/components/analysis-viewer.js
@@ -117,8 +117,12 @@ function renderUnnamedSpeakersWarning() {
     const verb = unnamed === 1 ? 'is' : 'are';
     const noun = unnamed === 1 ? 'speaker' : 'speakers';
     return `
-        <div class="overview-notice analysis-warning" role="status">
-            ${unnamed} of ${total} ${noun} ${verb} still unnamed. Rename them on the Transcript tab — the generated prompt will use raw labels like <code>SPEAKER_00</code> until you do.
+        <div class="analysis-warning" role="alert">
+            <span class="analysis-warning-icon" aria-hidden="true">⚠</span>
+            <div class="analysis-warning-body">
+                <strong>${unnamed} of ${total} ${noun} ${verb} still unnamed.</strong>
+                Rename them on the Transcript tab — the generated prompt will use raw labels like <code>SPEAKER_00</code> until you do.
+            </div>
         </div>
     `;
 }

--- a/frontend/js/components/analysis-viewer.js
+++ b/frontend/js/components/analysis-viewer.js
@@ -1,6 +1,7 @@
 function renderAnalysisTab(container, meetingId, meetingType) {
     if (meetingId) container.dataset.meetingId = meetingId;
     container.innerHTML = `
+        ${renderUnnamedSpeakersWarning()}
         <div class="analysis-generator">
             <p>Select a template to generate a prompt you can paste into any LLM for analysis.</p>
             <div class="form-group">
@@ -84,6 +85,7 @@ function buildPlainTextTranscript() {
 
 function renderPromptContent(container, prompt) {
     container.innerHTML = `
+        ${renderUnnamedSpeakersWarning()}
         <div class="analysis-content">
             <div class="analysis-actions">
                 <button class="btn btn-primary" onclick="copyPrompt()">Copy to clipboard</button>
@@ -93,6 +95,32 @@ function renderPromptContent(container, prompt) {
         </div>
     `;
     container.dataset.rawPrompt = prompt;
+}
+
+// Reads `window._speakerEditorState`, which is populated by
+// `renderSegments()` in transcript-viewer.js when the meeting loads.
+// If transcript-viewer.js changes that contract, update this read site.
+function getUnnamedSpeakersInfo() {
+    const state = window._speakerEditorState;
+    if (!state || !state.speakerIds || !state.speakers) return null;
+    const total = state.speakerIds.length;
+    const unnamed = state.speakerIds.filter(id =>
+        isUnidentifiedSpeaker(state.speakers[id] || id)
+    ).length;
+    return { unnamed, total };
+}
+
+function renderUnnamedSpeakersWarning() {
+    const info = getUnnamedSpeakersInfo();
+    if (!info || info.unnamed === 0) return '';
+    const { unnamed, total } = info;
+    const verb = unnamed === 1 ? 'is' : 'are';
+    const noun = unnamed === 1 ? 'speaker' : 'speakers';
+    return `
+        <div class="overview-notice analysis-warning" role="status">
+            ${unnamed} of ${total} ${noun} ${verb} still unnamed. Rename them on the Transcript tab — the generated prompt will use raw labels like <code>SPEAKER_00</code> until you do.
+        </div>
+    `;
 }
 
 function copyPrompt() {

--- a/frontend/js/components/analysis-viewer.js
+++ b/frontend/js/components/analysis-viewer.js
@@ -97,36 +97,6 @@ function renderPromptContent(container, prompt) {
     container.dataset.rawPrompt = prompt;
 }
 
-// Reads `window._speakerEditorState`, which is populated by
-// `renderSegments()` in transcript-viewer.js when the meeting loads.
-// If transcript-viewer.js changes that contract, update this read site.
-function getUnnamedSpeakersInfo() {
-    const state = window._speakerEditorState;
-    if (!state || !state.speakerIds || !state.speakers) return null;
-    const total = state.speakerIds.length;
-    const unnamed = state.speakerIds.filter(id =>
-        isUnidentifiedSpeaker(state.speakers[id] || id)
-    ).length;
-    return { unnamed, total };
-}
-
-function renderUnnamedSpeakersWarning() {
-    const info = getUnnamedSpeakersInfo();
-    if (!info || info.unnamed === 0) return '';
-    const { unnamed, total } = info;
-    const verb = unnamed === 1 ? 'is' : 'are';
-    const noun = unnamed === 1 ? 'speaker' : 'speakers';
-    return `
-        <div class="analysis-warning" role="alert">
-            <span class="analysis-warning-icon" aria-hidden="true">⚠</span>
-            <div class="analysis-warning-body">
-                <strong>${unnamed} of ${total} ${noun} ${verb} still unnamed.</strong>
-                Rename them on the Transcript tab — the generated prompt will use raw labels like <code>SPEAKER_00</code> until you do.
-            </div>
-        </div>
-    `;
-}
-
 function copyPrompt() {
     const container = document.getElementById('analysis-tab');
     const raw = container.dataset.rawPrompt || '';

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -478,6 +478,7 @@ function renderPlainTextTab(container) {
     const plainText = lines.join('\n');
 
     container.innerHTML = `
+        ${renderUnnamedSpeakersWarning()}
         <div class="plaintext-view">
             <div class="plaintext-actions">
                 <button class="btn btn-primary" onclick="copyPlainText()">Copy to clipboard</button>

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -46,6 +46,36 @@ function isUnidentifiedSpeaker(name) {
     return name === 'UNKNOWN' || /^SPEAKER_\d+$/.test(name);
 }
 
+// Reads `window._speakerEditorState`, populated by `renderSegments()` in
+// transcript-viewer.js when the meeting loads. If that contract changes,
+// update this read site.
+function getUnnamedSpeakersInfo() {
+    const state = window._speakerEditorState;
+    if (!state || !state.speakerIds || !state.speakers) return null;
+    const total = state.speakerIds.length;
+    const unnamed = state.speakerIds.filter(id =>
+        isUnidentifiedSpeaker(state.speakers[id] || id)
+    ).length;
+    return { unnamed, total };
+}
+
+function renderUnnamedSpeakersWarning() {
+    const info = getUnnamedSpeakersInfo();
+    if (!info || info.unnamed === 0) return '';
+    const { unnamed, total } = info;
+    const verb = unnamed === 1 ? 'is' : 'are';
+    const noun = unnamed === 1 ? 'speaker' : 'speakers';
+    return `
+        <div class="unnamed-speakers-warning" role="alert">
+            <span class="unnamed-speakers-warning-icon" aria-hidden="true">⚠</span>
+            <div class="unnamed-speakers-warning-body">
+                <strong>${unnamed} of ${total} ${noun} ${verb} still unnamed.</strong>
+                Rename them on the Transcript tab — copied text will use raw labels like <code>SPEAKER_00</code> until you do.
+            </div>
+        </div>
+    `;
+}
+
 function getRecentSpeakerNames() {
     try {
         return JSON.parse(localStorage.getItem('recentSpeakerNames') || '[]');


### PR DESCRIPTION
Closes [#74](https://github.com/nimblehq/audio-transcriber/issues/74)

## Summary

Adds a visible notice to the Analysis tab that surfaces when one or more speakers still carry raw diarization labels (e.g., `SPEAKER_00`, `UNKNOWN`). Without the notice it is easy to generate an LLM prompt that contains those raw IDs in place of meaningful names.

## Approach

- Reused the existing `isUnidentifiedSpeaker()` helper from `frontend/js/utils.js` and the `.overview-notice` banner pattern already used by the Overview tab, so visual styling stays consistent across tabs and benefits from dark/light theming for free.
- Two small helpers were added to `analysis-viewer.js`:
  - `getUnnamedSpeakersInfo()` reads `window._speakerEditorState` (populated by `transcript-viewer.renderSegments()` when the meeting loads) and returns `{ unnamed, total }`. An inline comment documents that cross-component dependency so a future refactor flags this read site.
  - `renderUnnamedSpeakersWarning()` returns the banner HTML if `unnamed > 0`, otherwise empty.
- The banner is prepended in both `renderAnalysisTab()` (initial view) and `renderPromptContent()` (post-generate view). Keeping it visible after Generate Prompt was an intentional choice — it's most useful precisely when the user is about to copy the prompt with raw labels embedded.
- A small `.analysis-warning` margin override and inline `<code>` styling were added to `frontend/css/styles.css`; the base banner appearance comes from `.overview-notice`.

Plan: `docs/plans/74-warn-unnamed-speakers-on-analysis.md`.

## Verification

Manual browser smoke-test against the running dev server:

- Meeting with 5/5 unnamed speakers → banner shows *"5 of 5 speakers are still unnamed. Rename them on the Transcript tab — the generated prompt will use raw labels like `SPEAKER_00` until you do."* both before and after clicking Generate Prompt.
- Meeting with all speakers named → no banner rendered.
- Counter copy is singular/plural-correct (verb and noun).
- `ruff check .` passes (no Python changes, but verified).

No frontend test framework exists in this repo, so no automated tests were added.