### PR TITLE
[#62] Wrap the app as a double-click macOS launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ __pycache__/
 # macOS
 .DS_Store
 
+# Built macOS launcher app (produced by scripts/build-app.sh)
+dist/
+
 # Audio source files (large)
 *.m4a
 *.mp3

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup run clean
+.PHONY: setup run app clean
 
 setup:
 	python3.12 -m venv .venv
@@ -10,6 +10,9 @@ setup:
 
 run:
 	. .venv/bin/activate && python run.py
+
+app:
+	./scripts/build-app.sh
 
 clean:
 	rm -rf .venv data/meetings/*

--- a/README.md
+++ b/README.md
@@ -101,6 +101,61 @@ Open http://localhost:8000 in your browser. You can now upload audio/video files
 
 > **Use `localhost`, not `0.0.0.0`.** Some browser features like desktop notifications require a secure context. Chrome treats `localhost` as secure, but not `0.0.0.0`.
 
+## Double-click launcher (macOS)
+
+Prefer not to touch the Terminal every time? Build a small macOS app that starts the
+server and opens your browser with a double-click. This is a convenience wrapper around
+the same `make setup` / `make run` steps above -- you still need the one-time setup
+(Python 3.12, ffmpeg, `make setup`, and your `HF_TOKEN`) done first.
+
+### Step 1: Build the app (one time)
+
+```bash
+make app
+```
+
+This produces `dist/Meeting Transcriber.app`. No prebuilt app is committed to the repo --
+the `dist/` folder is gitignored, so you build it once locally. The build bakes in the
+current location of this repo, so if you ever move the project folder, just run `make app`
+again.
+
+### Step 2: Install and first launch
+
+1. Drag `dist/Meeting Transcriber.app` to `/Applications` or your Dock.
+2. **First launch only:** right-click the app and choose **Open**, then confirm. The app is
+   not code-signed, so a plain double-click is blocked by Gatekeeper the first time.
+   (Alternatively: `xattr -dr com.apple.quarantine "/Applications/Meeting Transcriber.app"`.)
+
+### What it does
+
+Each double-click:
+
+1. Runs `git pull --ff-only` to grab the latest version (skipped automatically when you're
+   offline or this isn't a git checkout -- so code may change between launches).
+2. Refreshes Python dependencies (`pip install -r requirements.txt`).
+3. Starts the server in the background and opens http://localhost:8000.
+
+The app stays running with an icon in your Dock. **Quit it (Cmd-Q) to stop the server.**
+Quitting cancels any transcription still in progress -- jobs aren't resumable, so let them
+finish before you quit.
+
+Startup is near-instant on the warm path; the first launch after a dependency change is
+slower while `pip` installs.
+
+### Troubleshooting
+
+Anything that goes wrong (a rejected `git pull`, a dependency error, port 8000 already in
+use, the server failing to start) shows a dialog pointing at the log:
+
+```
+~/Library/Logs/MeetingTranscriber.log
+```
+
+> **Quitting at logout is best-effort.** Explicit Quit (Cmd-Q / Dock → Quit) reliably stops
+> the server. At logout or shutdown macOS may force-quit the app before it can stop the
+> server; if that happens, the next launch detects the running server and just reopens the
+> browser.
+
 ## Web App
 
 The web app lets you upload recordings, track transcription progress, view transcripts synchronized with audio playback, and generate LLM-ready prompts for analysis.

--- a/docs/plans/62-macos-double-click-launcher.md
+++ b/docs/plans/62-macos-double-click-launcher.md
@@ -1,0 +1,97 @@
+# Plan: Wrap the app as a double-click macOS launcher
+
+**Story**: #62
+**Spec**: N/A (no spec; rough ACs in the issue)
+**Branch**: feature/62-macos-double-click-launcher
+**Date**: 2026-06-04
+**Mode**: Standard — deliverable is shell + AppleScript glue + a build script; behavioral ACs require manual macOS verification and cannot run on the Linux CI.
+
+## Technical Decisions
+
+### TD-1: Build tool = `osacompile`, not Platypus
+- **Context**: The issue suggests Platypus or an AppleScript droplet to wrap a shell script into a `.app`.
+- **Decision**: Use `osacompile`, which ships with macOS — zero extra build dependency. Produces an AppleScript `.app`.
+- **Alternatives considered**: Platypus (nicer menu-bar UX but requires `brew install platypus` at build time). Deferred as optional future enhancement.
+
+### TD-2: App stays alive to own the uvicorn lifecycle
+- **Context**: AC3 requires that closing the app cleanly terminates uvicorn, so the app must outlive the launch and supervise uvicorn.
+- **Decision**: AppleScript app with `on run` (start), `on idle return 30` (stay alive, Dock presence), `on quit` (run stop.sh, then `continue quit`). AC3 ("closing the app cleanly terminates uvicorn") is dependably met for **explicit Quit** (Cmd-Q / Dock Quit). Logout/shutdown teardown is **best-effort**: macOS sends a Quit Apple Event at logout, but an osacompile `.app` running `do shell script` in `on quit` is subject to the quit-reply timeout, and uvicorn is `nohup`-detached from the launcher's process tree, so teardown depends entirely on stop.sh completing in time.
+- **Alternatives considered**: Platypus status-menu app (auto process-group teardown, but extra build dep); fire-and-forget launcher that quits immediately (cannot satisfy AC3).
+
+### TD-3: Deps refresh via venv + pip, not `uv`
+- **Context**: The issue proposes `uv sync --quiet`, but this repo does not use uv.
+- **Decision**: Match `make setup` exactly — ensure `.venv` exists (create with `python3.12 -m venv` if missing), then `pip install -q -r requirements.txt`.
+- **Alternatives considered**: `uv sync` (issue's proposal) — rejected; repo has no `uv.lock` and uses pip.
+
+### TD-4: uvicorn started without `--reload`, backgrounded with a pidfile
+- **Context**: `run.py` runs uvicorn with `reload=True`, which spawns a watcher subprocess complicating clean teardown.
+- **Decision**: Launch via `python -m uvicorn backend.main:app --host localhost --port 8000` (no reload), backgrounded with `nohup`, PID written to a pidfile under `~/Library/Application Support/MeetingTranscriber/`. `run.py` is left untouched.
+- **Alternatives considered**: Reusing `run.py` (reload-on; harder to terminate cleanly).
+
+### TD-5: Repo path resolved at build time
+- **Context**: Open question — where does the repo live on disk?
+- **Decision**: `build-app.sh` bakes the absolute repo root (`git rev-parse --show-toplevel`) into the generated AppleScript. Moving the repo means rebuilding. The `.app` can then live in `/Applications` or the Dock.
+- **Alternatives considered**: Hard-coded `~/Applications/audio-transcription`; runtime config file. Build-time bake is simplest and unambiguous.
+
+### TD-6: Kill (not detach) uvicorn on quit, bounded teardown
+- **Context**: Open question — kill or detach a long-running transcription on quit?
+- **Decision**: Kill. Job state is in-memory and not resumable; detaching would orphan uvicorn and violate AC3. `stop.sh` kills the uvicorn process group with a bounded grace: SIGTERM → wait up to 2s → SIGKILL, so it finishes within the logout quit-reply window. Idempotent; removes the pidfile.
+- **Alternatives considered**: Detach and let transcription finish (orphans the server; breaks AC3).
+
+### TD-7: Port-in-use uses an app-specific discriminator, not a bare 200
+- **Context**: The SPA catch-all route returns 200 for any path, so a bare 200 on :8000 cannot distinguish "our app" from a foreign process.
+- **Decision**: Probe `GET http://localhost:8000/api/meetings` (our API returns a JSON array). Three states: connection-refused/5xx → keep polling until ~20s timeout (our app booting); 200 + JSON-array shape → success (open browser; idempotent if already running); clearly-foreign 200 → `fail()` dialog "port 8000 in use by another process".
+- **Alternatives considered**: Bare 200 on `/` (false positives from the SPA catch-all and from foreign processes).
+
+### TD-8: No code signing / notarization
+- **Context**: Open question — needed for distribution?
+- **Decision**: Skip (single-user/internal tool). README documents the one-time Gatekeeper right-click→Open / `xattr -dr com.apple.quarantine`.
+- **Alternatives considered**: Full notarization (out of scope while single-user).
+
+### TD-9: Centralized failure handling with osascript dialogs
+- **Context**: AC4 — failures must show a dialog, not silent nothing.
+- **Decision**: A shared `fail()` shell function appends to `~/Library/Logs/MeetingTranscriber.log` and shows an `osascript display dialog` quoting the log path, then exits non-zero. Every failure path (git pull rejected, venv/pip error, port conflict, health timeout) routes through it. `launch.sh` owns the dialogs so they work whether invoked from the `.app` or directly.
+
+## Files to Create or Modify
+
+- `scripts/launch.sh` (create) — core launcher: resolve baked repo root, cd, `git pull --ff-only` (skip-with-log when offline / not a checkout), ensure venv, `pip install -q -r requirements.txt`, start uvicorn (no-reload, nohup, pidfile), poll `/api/meetings` until healthy or ~20s, `open` the URL, exit 0. Logs to `~/Library/Logs/MeetingTranscriber.log`. `fail()` helper shows osascript dialog.
+- `scripts/stop.sh` (create) — read pidfile, kill uvicorn process group (TERM → 2s → KILL), remove pidfile. Idempotent.
+- `scripts/launcher.applescript` (create) — `on run` → `do shell script "<repo>/scripts/launch.sh"`; `on idle return 30`; `on quit` → `do shell script "<repo>/scripts/stop.sh"`, `continue quit`. Repo path placeholder substituted at build time.
+- `scripts/build-app.sh` (create) — substitute repo path into a temp copy of the AppleScript, `osacompile -o "dist/Meeting Transcriber.app"`, apply `assets/MeetingTranscriber.icns` if present (best-effort), print next-step instructions. Guards: require macOS (Darwin) and `osacompile`.
+- `tests/test_launcher_scripts.py` (create) — `@pytest.mark.unit` test running `bash -n` on launch.sh and stop.sh; skips gracefully if `bash` is unavailable. Syntax guard only.
+- `README.md` (modify) — add "Double-click launcher (macOS)" section, leading with the required one-time build step; notes no prebuilt `.app` is committed, pull-on-launch behavior, Gatekeeper, log path, and that quitting cancels in-progress transcription.
+- `.gitignore` (modify) — add `dist/`.
+- `Makefile` (modify) — add `app:` target calling `scripts/build-app.sh`.
+
+## Approach per AC
+
+### AC 1: A `.app` exists in the repo (or a build script that produces one)
+`scripts/build-app.sh` (and a `make app` target) produce `dist/Meeting Transcriber.app` via `osacompile`. The bundle is gitignored (`dist/`); the build script is the committed artifact. README leads with this required one-time build step.
+
+### AC 2: Double-click on a fresh checkout (after one-time setup) opens the app in the browser within ~5s
+After building the `.app` once, double-click runs `launch.sh`: fast-forward pull, deps refresh (near-instant on the warm path), uvicorn boot, readiness poll on `/api/meetings`, then `open`. The ~5s target holds on the warm path (deps already satisfied); a real `pip install` exceeds it (documented).
+
+### AC 3: Closing the app cleanly terminates uvicorn
+`on quit` runs `stop.sh`, which TERMs then KILLs the uvicorn process group via the pidfile. Dependable for explicit Quit; logout/shutdown is best-effort (TD-2).
+
+### AC 4: Failures show a dialog, not silent nothing
+Every failure path routes through `fail()`, which logs and shows an `osascript display dialog` with the log path, then exits non-zero.
+
+## Commit Sequence
+
+1. `scripts/launch.sh` + `scripts/stop.sh`
+2. `scripts/launcher.applescript` + `scripts/build-app.sh` + Makefile `app` target + `.gitignore`
+3. `tests/test_launcher_scripts.py`
+4. README docs
+
+## Risks and Trade-offs
+
+- **AC2 "~5s"** only holds on the warm path; a real `pip install` blows past it. Documented.
+- **Unsigned `.app`** → Gatekeeper friction on first open. Mitigated by docs, not eliminated.
+- **Logout/shutdown teardown** is best-effort — osacompile quit-reply timeout + `nohup` detachment mean uvicorn may be orphaned if `stop.sh` doesn't finish in the reply window. A LaunchAgent (RunAtLoad, KeepAlive=false) backstop that reaps a stale pidfile on next login is noted as future hardening, out of scope here.
+- **Behavioral ACs unverifiable in Linux CI** → manual macOS verification is the real gate; `bash -n` is a syntax guard only.
+- **Pull on every launch** couples launch to network + git state; skipped when offline / not a checkout. Documented so behavior changes between launches are expected.
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/docs/plans/62-macos-double-click-launcher.md
+++ b/docs/plans/62-macos-double-click-launcher.md
@@ -94,4 +94,11 @@ Every failure path routes through `fail()`, which logs and shows an `osascript d
 
 ## Deviations from Plan
 
-_Populated after implementation._
+- None of substance — the implementation followed the plan. One refinement from the
+  Architect code review: `build-app.sh` now compiles inside a `mktemp -d` temp directory
+  (trapped for cleanup) instead of a suffixed temp file, to avoid leaving an orphaned base
+  temp file on each build.
+- AC2 (~5s) and AC3 (quit terminates uvicorn) were verified for logical correctness and
+  the `.app` build was exercised on macOS, but their wall-clock/runtime confirmation
+  requires a fully configured environment (Python 3.12 venv + ML deps + `HF_TOKEN`) and a
+  manual macOS smoke test, which remains the real gate for those two ACs.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# build-app.sh — build "dist/Meeting Transcriber.app" from launcher.applescript.
+#
+# Uses osacompile (ships with macOS), so there is no extra build dependency.
+# The absolute repo path is baked into the app at build time; move the repo and
+# rebuild. The built .app is gitignored — this script is the committed artifact.
+
+set -euo pipefail
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "build-app.sh requires macOS (osacompile)." >&2
+  exit 1
+fi
+if ! command -v osacompile >/dev/null 2>&1; then
+  echo "osacompile not found (expected on macOS)." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+if git -C "$REPO_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+  REPO_ROOT="$(git -C "$REPO_ROOT" rev-parse --show-toplevel)"
+fi
+
+SRC="$REPO_ROOT/scripts/launcher.applescript"
+DIST="$REPO_ROOT/dist"
+APP="$DIST/Meeting Transcriber.app"
+ICON="$REPO_ROOT/assets/MeetingTranscriber.icns"
+
+mkdir -p "$DIST"
+rm -rf "$APP"
+
+tmp="$(mktemp -t launcher.XXXXXX).applescript"
+trap 'rm -f "$tmp"' EXIT
+# Escape characters special to sed's replacement (&, |, \) in the repo path.
+escaped_root="$(printf '%s' "$REPO_ROOT" | sed -e 's/[&|\\]/\\&/g')"
+sed "s|__REPO_ROOT__|$escaped_root|g" "$SRC" >"$tmp"
+
+osacompile -o "$APP" "$tmp"
+
+if [ -f "$ICON" ]; then
+  cp "$ICON" "$APP/Contents/Resources/applet.icns"
+  echo "Applied custom icon."
+fi
+
+echo "Built: $APP"
+echo
+echo "Next steps:"
+echo "  1. Drag \"$APP\" to /Applications or your Dock."
+echo "  2. First launch: right-click the app and choose Open to clear Gatekeeper."
+echo "  3. Double-click to start. Quit (Cmd-Q) to stop the server."

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -31,8 +31,9 @@ ICON="$REPO_ROOT/assets/MeetingTranscriber.icns"
 mkdir -p "$DIST"
 rm -rf "$APP"
 
-tmp="$(mktemp -t launcher.XXXXXX).applescript"
-trap 'rm -f "$tmp"' EXIT
+tmpdir="$(mktemp -d -t meeting-transcriber-build.XXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT
+tmp="$tmpdir/launcher.applescript"
 # Escape characters special to sed's replacement (&, |, \) in the repo path.
 escaped_root="$(printf '%s' "$REPO_ROOT" | sed -e 's/[&|\\]/\\&/g')"
 sed "s|__REPO_ROOT__|$escaped_root|g" "$SRC" >"$tmp"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# launch.sh — start the Meeting Transcriber app from a double-click launcher.
+#
+# Flow: fast-forward pull -> refresh deps (venv + pip) -> start uvicorn in the
+# background -> wait until it answers -> open the browser. Every failure path
+# logs to ~/Library/Logs/MeetingTranscriber.log and surfaces an osascript
+# dialog quoting the log path, so the user always gets a breadcrumb.
+#
+# Safe to run directly from a terminal as well as from the built .app.
+
+set -u
+
+# `do shell script` (the .app entry point) runs with a minimal PATH, so the
+# tools we rely on (git, python3.12, curl, open) must be reachable. Prepend the
+# common Homebrew/macOS locations.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+LOG_DIR="$HOME/Library/Logs"
+LOG_FILE="$LOG_DIR/MeetingTranscriber.log"
+SUPPORT_DIR="$HOME/Library/Application Support/MeetingTranscriber"
+PID_FILE="$SUPPORT_DIR/uvicorn.pid"
+
+URL="http://localhost:8000"
+API_URL="$URL/api/meetings"
+READY_TIMEOUT=20
+
+mkdir -p "$LOG_DIR" "$SUPPORT_DIR"
+
+log() {
+  printf '%s  %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >>"$LOG_FILE"
+}
+
+# fail <message> — log, show a dialog pointing at the log, and exit non-zero.
+fail() {
+  local message="$1"
+  log "ERROR: $message"
+  if command -v osascript >/dev/null 2>&1; then
+    osascript >/dev/null 2>&1 <<OSA || true
+display dialog "Meeting Transcriber could not start.
+
+$message
+
+See the log for details:
+$LOG_FILE" buttons {"OK"} default button "OK" with title "Meeting Transcriber" with icon caution
+OSA
+  fi
+  exit 1
+}
+
+# probe — classify what is answering on port 8000.
+# Echoes one of: "ours" | "foreign" | "down". Never fails the script.
+probe() {
+  local body code
+  body="$(mktemp)"
+  code="$(curl -s -m 3 -o "$body" -w '%{http_code}' "$API_URL" 2>/dev/null)"
+  local curl_exit=$?
+  if [ "$curl_exit" -ne 0 ]; then
+    rm -f "$body"
+    echo "down"
+    return
+  fi
+  if [ "$code" = "200" ] && [ "$(head -c 1 "$body")" = "[" ]; then
+    rm -f "$body"
+    echo "ours"
+    return
+  fi
+  rm -f "$body"
+  echo "foreign"
+}
+
+open_browser() {
+  log "Opening $URL"
+  open "$URL" 2>>"$LOG_FILE" || true
+}
+
+log "----- launch start ($REPO_ROOT) -----"
+
+# 1. If our app is already serving, just bring the browser forward (idempotent).
+case "$(probe)" in
+  ours)
+    log "App already running; opening browser."
+    open_browser
+    exit 0
+    ;;
+  foreign)
+    fail "Port 8000 is already in use by another process. Quit it and try again."
+    ;;
+esac
+
+cd "$REPO_ROOT" || fail "Could not enter the project folder: $REPO_ROOT"
+
+# 2. Fast-forward pull (best effort: skip when offline or not a git checkout).
+if [ -d "$REPO_ROOT/.git" ] || git rev-parse --git-dir >/dev/null 2>&1; then
+  log "Pulling latest changes (git pull --ff-only)..."
+  if git pull --ff-only >>"$LOG_FILE" 2>&1; then
+    log "Pull complete."
+  else
+    status=$?
+    # A rejected fast-forward means local/remote diverged — that is a real
+    # problem the user should know about. A network failure is not.
+    if git status --porcelain=v1 -b 2>/dev/null | grep -q '\[ahead\|\[behind\|diverged'; then
+      fail "Could not update the app (git pull --ff-only was rejected). Your local copy may have diverged from the remote."
+    fi
+    log "Pull skipped (offline or unavailable, exit $status); continuing with the local copy."
+  fi
+else
+  log "Not a git checkout; skipping update."
+fi
+
+# 3. Ensure the virtual environment and dependencies.
+VENV_PY="$REPO_ROOT/.venv/bin/python"
+if [ ! -x "$VENV_PY" ]; then
+  command -v python3.12 >/dev/null 2>&1 || fail "Python 3.12 is required but was not found. Run the one-time setup (see README) first."
+  log "Creating virtual environment..."
+  python3.12 -m venv "$REPO_ROOT/.venv" >>"$LOG_FILE" 2>&1 || fail "Could not create the Python virtual environment."
+fi
+log "Refreshing dependencies..."
+"$VENV_PY" -m pip install -q -r "$REPO_ROOT/requirements.txt" >>"$LOG_FILE" 2>&1 || fail "Could not install Python dependencies."
+
+# 4. Start uvicorn (no --reload, so there is a single process to terminate).
+log "Starting server..."
+nohup "$VENV_PY" -m uvicorn backend.main:app --host localhost --port 8000 \
+  >>"$LOG_FILE" 2>&1 &
+echo $! >"$PID_FILE"
+log "Server PID $(cat "$PID_FILE")."
+
+# 5. Wait until the server answers (connection-refused/5xx => keep waiting).
+deadline=$((SECONDS + READY_TIMEOUT))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if [ "$(probe)" = "ours" ]; then
+    log "Server is ready."
+    open_browser
+    log "----- launch done -----"
+    exit 0
+  fi
+  # If the process died, stop waiting and report.
+  pid="$(cat "$PID_FILE" 2>/dev/null)"
+  if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+    fail "The server process exited unexpectedly during startup."
+  fi
+  sleep 1
+done
+
+fail "The server did not become ready within ${READY_TIMEOUT}s."

--- a/scripts/launcher.applescript
+++ b/scripts/launcher.applescript
@@ -1,0 +1,29 @@
+-- launcher.applescript — source for the "Meeting Transcriber" .app.
+--
+-- build-app.sh substitutes __REPO_ROOT__ with the absolute repo path at build
+-- time. The app stays alive (on idle) so that quitting it (Cmd-Q / Dock Quit,
+-- or logout) tears the server down via stop.sh.
+--
+-- launch.sh owns its own failure dialogs, so on run swallows shell errors.
+
+property launchScript : "__REPO_ROOT__/scripts/launch.sh"
+property stopScript : "__REPO_ROOT__/scripts/stop.sh"
+
+on run
+	try
+		do shell script quoted form of launchScript
+	on error
+		-- launch.sh already showed a dialog on any failure path.
+	end try
+end run
+
+on idle
+	return 30
+end idle
+
+on quit
+	try
+		do shell script quoted form of stopScript
+	end try
+	continue quit
+end quit

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# stop.sh — terminate the background uvicorn server started by launch.sh.
+#
+# Bounded teardown: SIGTERM, wait up to ~2s, then SIGKILL. Kept fast so it can
+# finish inside the logout quit-reply window. Idempotent — safe to run when the
+# server is already gone.
+
+set -u
+
+LOG_FILE="$HOME/Library/Logs/MeetingTranscriber.log"
+PID_FILE="$HOME/Library/Application Support/MeetingTranscriber/uvicorn.pid"
+
+log() {
+  printf '%s  %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >>"$LOG_FILE" 2>/dev/null
+}
+
+[ -f "$PID_FILE" ] || exit 0
+pid="$(cat "$PID_FILE" 2>/dev/null)"
+
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+  log "Stopping server (PID $pid)..."
+  kill -TERM "$pid" 2>/dev/null
+  for _ in 1 2 3 4; do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.5
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    log "Server did not exit; sending SIGKILL."
+    kill -KILL "$pid" 2>/dev/null
+  fi
+  log "Server stopped."
+fi
+
+rm -f "$PID_FILE"

--- a/tests/test_launcher_scripts.py
+++ b/tests/test_launcher_scripts.py
@@ -1,0 +1,36 @@
+"""Syntax guard for the macOS launcher shell scripts.
+
+`bash -n` only parses (it never executes), so this is a syntax-only regression
+guard with near-zero behavioral coverage. The behavioral acceptance criteria
+(double-click, browser opens, quit terminates uvicorn) require manual macOS
+verification. Skips gracefully when bash is unavailable (e.g. some CI images).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHELL_SCRIPTS = [
+    REPO_ROOT / "scripts" / "launch.sh",
+    REPO_ROOT / "scripts" / "stop.sh",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("script", SHELL_SCRIPTS, ids=lambda path: path.name)
+def test_shell_script_has_valid_syntax(script: Path) -> None:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is not available")
+    assert script.exists(), f"missing script: {script}"
+    result = subprocess.run(
+        [bash, "-n", str(script)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Closes [#62](https://github.com/nimblehq/audio-transcriber/issues/62)

## Summary

Adds a macOS double-click launcher so non-technical users can start the app without touching the Terminal. Running `make app` builds a small `dist/Meeting Transcriber.app` that, on double-click:

1. Runs `git pull --ff-only` to update the local clone (skipped when offline / not a git checkout)
2. Refreshes Python deps (`pip install -r requirements.txt` into `.venv`)
3. Starts `uvicorn` in the background (no `--reload`)
4. Opens http://localhost:8000 in the default browser
5. On Quit (Cmd-Q / Dock → Quit) cleanly terminates the server

Failures (rejected pull, dependency error, port in use, server not ready) surface an `osascript` dialog pointing at `~/Library/Logs/MeetingTranscriber.log` instead of failing silently.

First-run setup (Python 3.12, ffmpeg, `HF_TOKEN`, model download) remains out of scope and is tracked separately, as noted in the issue.

## Approach

- **`osacompile`, not Platypus** — ships with macOS, so there is no extra build dependency. `scripts/build-app.sh` (exposed as `make app`) bakes the absolute repo path into an AppleScript stub and compiles it. The built `.app` is gitignored (`dist/`); the build script is the committed artifact, which satisfies the AC's "a `.app` exists in the repo **or** a build script that produces one."
- **venv + pip, not `uv`** — the issue's proposal mentioned `uv sync`, but this repo uses `make setup` (venv + pip). The launcher matches the real setup exactly.
- **App owns the server lifecycle** — the AppleScript app stays alive (`on idle`) with a Dock icon; `on quit` runs `scripts/stop.sh`, which terminates the server via a pidfile (SIGTERM → 2s → SIGKILL). Clean termination is dependable for explicit Quit; logout/shutdown teardown is best-effort (osacompile quit-reply timeout + `nohup` detachment) and documented, with a LaunchAgent backstop noted as future hardening.
- **Port discrimination** — readiness/port-in-use checks probe `GET /api/meetings` (a JSON array) rather than a bare 200, since the SPA catch-all returns 200 for any path.

Design and rationale captured in `docs/plans/62-macos-double-click-launcher.md`. The plan and both review gates (Architect plan review + code review) passed.

## Verification

- `bash -n` syntax check on all three shell scripts (also enforced by `tests/test_launcher_scripts.py`, a `unit`-marked test that passes locally).
- `ruff check` / `ruff format --check` clean on the new test file.
- Built the app end-to-end on macOS: `make app` produces a valid `.app` bundle and the repo path is correctly baked into the compiled script (`osadecompile` confirmed).
- Architect plan review: pass (iteration 2). Architect code review: pass, no Critical/Major; one Minor (orphaned temp file in the build script) fixed.

> **Manual macOS runtime verification still recommended:** the behavioral ACs (browser opens within ~5s; Quit terminates uvicorn) require a fully configured environment (Python 3.12 venv with the ML deps + `HF_TOKEN`) and cannot run on the Linux CI, which only runs the `bash -n` guard. Reviewer should double-click the built app once in a real setup to confirm start/stop.
