### PR TITLE
[#82] Add Conductor setup and run scripts

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,6 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "make setup"
+run = ". .venv/bin/activate && uvicorn backend.main:app --host localhost --port $CONDUCTOR_PORT --reload"
+run_mode = "concurrent"

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,7 @@
+# Files copied into each new Conductor workspace.
+# Only gitignored files need listing here; tracked files arrive via git.
+#
+# .env holds HF_TOKEN, required for speaker diarization. .env.example is
+# tracked, so it comes through git already.
+.env
+.env.local


### PR DESCRIPTION
Closes [#82](https://github.com/nimblehq/audio-transcriber/issues/82)

## Summary

Adds committed [Conductor](https://www.conductor.build/docs/configure-your-project) repository configuration so each new Conductor workspace (a separate git worktree/branch) is automatically prepared:

- **Setup** installs the Python 3.12 virtualenv and dependencies via the existing `make setup`.
- **Files to copy** brings the gitignored `.env` (holding `HF_TOKEN`, required for speaker diarization) into every new workspace.
- **Run** starts the FastAPI app on the workspace-assigned `CONDUCTOR_PORT`, so multiple workspaces can run at once.

The repo previously had no Conductor configuration, so new workspaces had no automated setup or run command.

## Approach

`.conductor/settings.toml`:
- `setup = "make setup"` reuses the existing documented setup path (workspace-local `.venv` + `requirements.txt`). The large PyTorch download per worktree is inherent to isolated worktrees.
- `run` invokes `uvicorn` directly — the faithful equivalent of `run.py`'s `uvicorn.run("backend.main:app", host="localhost", port=8000, reload=True)` — so the port can be parametrized to `$CONDUCTOR_PORT` **without** modifying `run.py`. It keeps `--host localhost` (the README requires `localhost`, not `0.0.0.0`, for secure-context browser features like desktop notifications) and `--reload` to match `run.py`.
- `run_mode = "concurrent"` is safe because each worktree isolates its own `.venv`, its own `./data` (`DATA_DIR` defaults to `./data`), and its own port. There is no shared database, Redis, or fixed external port.

`.worktreeinclude` is the worktree copy mechanism for the gitignored `.env` (`.env.example` is tracked, so it arrives via git already). This is the highest-priority Files-to-copy resolution path, chosen over `file_include_globs` to avoid a schema-vs-docs ambiguity about that key.

No application code is modified: `make run` and `run.py` retain their hardcoded port 8000 for non-Conductor use.

## Verification

- `.conductor/settings.toml` parses cleanly (`python3.12 -m tomllib`) and contains only schema-valid keys (`$schema`, `[scripts]` with `setup`/`run`/`run_mode`).
- No Python code changed, so the test suite is unaffected.
- Plan reviewed and approved by the Argus architect agent (the initial draft incorrectly used `file_include_globs` as the copy mechanism; corrected to `.worktreeinclude`).
- Manual validation after merge: create a fresh Conductor workspace and confirm `.env` is copied, `make setup` builds the venv, and the Run button serves the app on the assigned `localhost:$CONDUCTOR_PORT`.