### PR TITLE
[#84] Make Conductor run script self-provision the venv

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,5 +2,5 @@
 
 [scripts]
 setup = "make setup"
-run = ". .venv/bin/activate && uvicorn backend.main:app --host localhost --port $CONDUCTOR_PORT --reload"
+run = "make run PORT=$CONDUCTOR_PORT"
 run_mode = "concurrent"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,28 @@
 .PHONY: setup run clean
 
-setup:
-	python3.12 -m venv .venv
-	. .venv/bin/activate && pip install -r requirements.txt
+VENV := .venv
+PORT ?= 8000
+
+# Build the virtualenv and install dependencies. The uvicorn binary doubles
+# as a build stamp: if it's missing (fresh worktree) or requirements.txt is
+# newer, the venv is (re)built. This lets `run` self-provision so a skipped or
+# interrupted `setup` can't leave a half-built or missing .venv behind.
+$(VENV)/bin/uvicorn: requirements.txt
+	python3.12 -m venv $(VENV)
+	$(VENV)/bin/pip install -r requirements.txt
+
+setup: $(VENV)/bin/uvicorn
 	@echo ""
 	@echo "Setup complete. Now configure your API key:"
 	@echo "  cp .env.example .env"
 	@echo "  Then edit .env and add your HuggingFace token"
 
-run:
-	. .venv/bin/activate && python run.py
+# Always launch via the venv's own interpreter (never `source activate`), so
+# the workspace's Python is used regardless of any venv active in the parent
+# shell. Override the port with `make run PORT=1234` (Conductor passes
+# $CONDUCTOR_PORT this way).
+run: $(VENV)/bin/uvicorn
+	PORT=$(PORT) $(VENV)/bin/python run.py
 
 clean:
-	rm -rf .venv data/meetings/*
+	rm -rf $(VENV) data/meetings/*

--- a/run.py
+++ b/run.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
+import os
+
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("backend.main:app", host="localhost", port=8000, reload=True)
+    # Host stays localhost: some browser features (e.g. desktop notifications)
+    # require a secure context, which Chrome grants to localhost but not 0.0.0.0.
+    # PORT defaults to 8000 for local dev; Conductor passes $CONDUCTOR_PORT so
+    # multiple workspaces can run concurrently.
+    uvicorn.run(
+        "backend.main:app",
+        host="localhost",
+        port=int(os.environ.get("PORT", "8000")),
+        reload=True,
+    )


### PR DESCRIPTION
Closes #84

## Summary

Fixes the `ModuleNotFoundError: No module named 'encodings'` crash when starting the app from a Conductor workspace (a separate git worktree) whose `.venv` is missing or half-built.

`.venv/` is gitignored, so `git worktree` does not copy it from the main checkout. Both run paths used `. .venv/bin/activate && <cmd>`; sourcing a missing `activate` is a silent no-op, so the command fell through to whatever `python`/`uvicorn` the parent shell exported — an interpreter from another checkout that can't resolve its stdlib here, producing the cryptic `encodings` crash.

## Changes

- **`Makefile`** — `run` depends on a build stamp (`.venv/bin/uvicorn`), so a skipped or interrupted `setup` self-provisions the venv before launch. Launch is `PORT=$(PORT) .venv/bin/python run.py` — the venv's **own** interpreter, never `source activate`, so the parent shell's active venv can't leak in. `PORT ?= 8000`, overridable with `make run PORT=...`.
- **`run.py`** — reads `PORT` from env (default 8000); host stays `localhost` and `reload` is kept. Single launch definition shared by local dev and Conductor.
- **`.conductor/settings.toml`** — `run = "make run PORT=$CONDUCTOR_PORT"`, routing Conductor through the same hardened Makefile path.

## Verification

- `make -n run` with no venv resolves to: build venv → `pip install` → `PORT=8000 .venv/bin/python run.py`.
- `make run PORT=39123` propagates the port.
- `.conductor/settings.toml` parses as valid TOML (`python3.12 -m tomllib`).
- `make run` default and `python run.py` continue to serve `localhost:8000` for non-Conductor use.

## Notes

Branch name lacks a `fix/` prefix, so `bug` label is applied manually (required for the release-bump signal).