### PR TITLE
[#78] Keep timestamps and speaker assignment accurate across language switches

### DIFF
--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -370,10 +370,10 @@ def _run_single_language_transcription(
 def _finite(value, fallback: float) -> float:
     """Coerce ``value`` to a finite float, falling back when it is missing/NaN/inf."""
     try:
-        result = float(value)
+        coerced = float(value)
     except (TypeError, ValueError):
         return fallback
-    return result if math.isfinite(result) else fallback
+    return coerced if math.isfinite(coerced) else fallback
 
 
 def _segment_level(group: list[dict], language: str) -> list[dict]:

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import threading
 import time
+from collections import defaultdict
 from pathlib import Path
 
 from backend.schemas import (
@@ -365,22 +367,114 @@ def _run_single_language_transcription(
     return segments, detected_language, diarize_turns
 
 
+def _finite(value, fallback: float) -> float:
+    """Coerce ``value`` to a finite float, falling back when it is missing/NaN/inf."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return result if math.isfinite(result) else fallback
+
+
+def _segment_level(group: list[dict], language: str) -> list[dict]:
+    """Segment-level (chunk) timestamps with text untouched and no word data.
+
+    Used when a language has no alignment model (BR-9, EC-3) or when alignment
+    fails (Truth-2: degrade timing only, never the transcript text).
+    """
+    return [{"start": s["start"], "end": s["end"], "text": s["text"], "language": language} for s in group]
+
+
+def _finalize_aligned(segments: list[dict], group: list[dict], language: str) -> list[dict]:
+    """Stamp the (single) language on each aligned segment and guarantee usable timing.
+
+    ``whisperx.align`` sentence-splits its input, so the output count differs from
+    the input — segments are never positionally zipped back. Every segment from a
+    single ``align`` call shares one language, so ``language`` is re-attached as a
+    constant (BR-8). Non-finite timestamps are repaired to keep the player's
+    seek/highlight (AC3) deterministic.
+    """
+    if not segments:
+        return _segment_level(group, language)
+
+    finalized: list[dict] = []
+    last_end = group[0]["start"] if group else 0.0
+    for seg in segments:
+        start = _finite(seg.get("start"), last_end)
+        end = _finite(seg.get("end"), start)
+        if end < start:
+            end = start
+        seg["start"], seg["end"], seg["language"] = start, end, language
+        finalized.append(seg)
+        last_end = end
+    return finalized
+
+
+def _align_multilingual_segments(ml_segments: list[dict], audio, device: str) -> list[dict]:
+    """Group segments by detected language and align each group with its own model.
+
+    Segments are grouped by their ``language`` field and each group is aligned with
+    that language's alignment model (BR-8), using the custom model from
+    ``CUSTOM_ALIGN_MODELS`` where one is configured. Languages without an alignment
+    model, or whose alignment raises, retain segment-level timestamps with text
+    unchanged (BR-9, EC-3, Truth-2). Returns a flat list sorted by start time.
+    """
+    import torch
+    import whisperx
+
+    by_language: dict[str, list[dict]] = defaultdict(list)
+    for seg in ml_segments:
+        by_language[seg["language"]].append(seg)
+
+    aligned: list[dict] = []
+    for language in sorted(by_language):
+        group = by_language[language]
+        if language not in ALIGNMENT_LANGUAGES:
+            aligned.extend(_segment_level(group, language))
+            continue
+        try:
+            align_model_name = CUSTOM_ALIGN_MODELS.get(language)
+            model_a, align_metadata = whisperx.load_align_model(
+                language_code=language, device=device, model_name=align_model_name
+            )
+            try:
+                result = whisperx.align(
+                    [{"start": s["start"], "end": s["end"], "text": s["text"]} for s in group],
+                    model_a,
+                    align_metadata,
+                    audio,
+                    device,
+                    return_char_alignments=False,
+                )
+            finally:
+                del model_a
+                if device == "cuda":
+                    torch.cuda.empty_cache()
+            aligned.extend(_finalize_aligned(result["segments"], group, language))
+        except Exception:
+            logger.exception("Alignment failed for language %s; retaining segment-level timestamps", language)
+            aligned.extend(_segment_level(group, language))
+
+    aligned.sort(key=lambda s: s["start"])
+    return aligned
+
+
 def _run_multilingual_transcription(
     job_id: str,
     audio,
     selected_languages: set[str],
+    num_speakers: int | None,
     device: str,
     compute_type: str,
-) -> tuple[list[dict], str]:
-    """Per-chunk multilingual pipeline (BR-4 through BR-7).
+) -> tuple[list[dict], str, list[tuple[float, float, str]] | None]:
+    """Per-chunk multilingual pipeline (BR-4 through BR-9).
 
     Triggered for 2+ expected languages. Each VAD speech chunk is detected
-    (constrained to the selected set) and transcribed in its own language.
-
-    Timestamps stay at chunk level and speakers are left UNKNOWN — word-level
-    alignment and cross-language speaker assignment are a later slice (BR-8/BR-9),
-    so this path runs neither alignment nor diarization.
-    Returns (segments, detected_language) where detected_language is the dominant.
+    (constrained to the selected set) and transcribed in its own language, then
+    segments are grouped by detected language and word-aligned per language (BR-8,
+    BR-9) before the shared diarization / speaker-assignment stage.
+    Returns (segments, detected_language, diarize_turns) where detected_language is
+    the dominant.
     """
     import torch
     import whisperx
@@ -390,7 +484,8 @@ def _run_multilingual_transcription(
     model = whisperx.load_model(WHISPER_MODEL, device, compute_type=compute_type)
 
     def _progress(pct: int) -> None:
-        job_queue.update_job(job_id, stage="transcribing", progress=min(pct, 89))
+        # Cap below the alignment/diarization stages so they have progress headroom.
+        job_queue.update_job(job_id, stage="transcribing", progress=min(pct, 80))
 
     ml_segments, detected_language = transcribe_multilingual(audio, selected_languages, model, progress_cb=_progress)
 
@@ -401,20 +496,27 @@ def _run_multilingual_transcription(
     if not ml_segments:
         raise RuntimeError("No speech detected in audio")
 
+    # Per-language word alignment (BR-8, BR-9, EC-3).
+    job_queue.update_job(job_id, stage="aligning", progress=82)
+    aligned = _align_multilingual_segments(ml_segments, audio, device)
+
+    # Diarize + assign speakers (shared with the single-language path).
+    result, diarize_turns = _diarize_and_assign(job_id, audio, num_speakers, device, {"segments": aligned}, progress=85)
+
     segments = []
-    for i, seg in enumerate(ml_segments):
+    for i, seg in enumerate(result["segments"]):
         segments.append(
             {
                 "id": f"seg_{i:04d}",
                 "start": round(seg["start"], 2),
                 "end": round(seg["end"], 2),
-                "speaker": "UNKNOWN",
+                "speaker": seg.get("speaker", "UNKNOWN"),
                 "text": seg["text"].strip(),
                 "language": seg["language"],
             }
         )
 
-    return segments, detected_language
+    return segments, detected_language, diarize_turns
 
 
 def _run_transcription(meeting_id: str, job_id: str):
@@ -472,8 +574,8 @@ def _run_transcription(meeting_id: str, job_id: str):
         # detection and transcription.
         diarize_turns: list[tuple[float, float, str]] | None = None
         if len(metadata.expected_languages) >= 2:
-            segments, detected_language = _run_multilingual_transcription(
-                job_id, audio, set(metadata.expected_languages), device, compute_type
+            segments, detected_language, diarize_turns = _run_multilingual_transcription(
+                job_id, audio, set(metadata.expected_languages), metadata.num_speakers, device, compute_type
             )
         else:
             segments, detected_language, diarize_turns = _run_single_language_transcription(

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -59,6 +59,56 @@ CUSTOM_ALIGN_MODELS = {
 }
 
 
+def _diarize_and_assign(
+    job_id: str,
+    audio,
+    num_speakers: int | None,
+    device: str,
+    result: dict,
+    *,
+    progress: int = 70,
+) -> tuple[dict, list[tuple[float, float, str]] | None]:
+    """Run PyAnnote diarization and assign speakers to the transcript result.
+
+    Shared by the single-language and multilingual pipelines. No-op (returns the
+    result unchanged with no turns) when HF_TOKEN is unset. Returns
+    ``(result_with_speakers, diarize_turns)`` where ``diarize_turns`` are the raw
+    PyAnnote turns (with overlaps) required by interaction analysis (BR-3.1).
+    """
+    if not HF_TOKEN:
+        return result, None
+
+    import torch
+    from whisperx.diarize import DiarizationPipeline, assign_word_speakers
+
+    job_queue.update_job(job_id, stage="diarizing", progress=progress)
+    diarize_model = DiarizationPipeline(
+        model_name="pyannote/speaker-diarization-3.1",
+        token=HF_TOKEN,
+        device=device,
+    )
+    diarize_kwargs = {}
+    if num_speakers:
+        diarize_kwargs["num_speakers"] = num_speakers
+    diarize_segments = diarize_model(audio, **diarize_kwargs)
+    # Capture raw PyAnnote turns (with overlaps) before assign_word_speakers
+    # collapses them into per-speaker non-overlapping transcript segments.
+    # Required by interaction analysis (BR-3.1).
+    try:
+        diarize_turns = [
+            (float(row["start"]), float(row["end"]), str(row["speaker"])) for _, row in diarize_segments.iterrows()
+        ]
+    except Exception:
+        logger.exception("Failed to capture raw diarization turns; interaction analysis will be unavailable")
+        diarize_turns = None
+    result = assign_word_speakers(diarize_segments, result)
+
+    if device == "cuda":
+        torch.cuda.empty_cache()
+
+    return result, diarize_turns
+
+
 def _get_device() -> str:
     if WHISPER_DEVICE != "auto":
         return WHISPER_DEVICE
@@ -232,7 +282,6 @@ def _run_single_language_transcription(
     """
     import torch
     import whisperx
-    from whisperx.diarize import DiarizationPipeline, assign_word_speakers
 
     # Transcribe
     job_queue.update_job(job_id, stage="transcribing", progress=20)
@@ -297,30 +346,8 @@ def _run_single_language_transcription(
         if device == "cuda":
             torch.cuda.empty_cache()
 
-    # Diarize
-    diarize_turns: list[tuple[float, float, str]] | None = None
-    if HF_TOKEN:
-        job_queue.update_job(job_id, stage="diarizing", progress=70)
-        diarize_model = DiarizationPipeline(
-            model_name="pyannote/speaker-diarization-3.1",
-            token=HF_TOKEN,
-            device=device,
-        )
-        diarize_kwargs = {}
-        if metadata.num_speakers:
-            diarize_kwargs["num_speakers"] = metadata.num_speakers
-        diarize_segments = diarize_model(audio, **diarize_kwargs)
-        # Capture raw PyAnnote turns (with overlaps) before assign_word_speakers
-        # collapses them into per-speaker non-overlapping transcript segments.
-        # Required by interaction analysis (BR-3.1).
-        try:
-            diarize_turns = [
-                (float(row["start"]), float(row["end"]), str(row["speaker"])) for _, row in diarize_segments.iterrows()
-            ]
-        except Exception:
-            logger.exception("Failed to capture raw diarization turns; interaction analysis will be unavailable")
-            diarize_turns = None
-        result = assign_word_speakers(diarize_segments, result)
+    # Diarize + assign speakers (shared with the multilingual path)
+    result, diarize_turns = _diarize_and_assign(job_id, audio, metadata.num_speakers, device, result)
 
     # Build transcript segments
     segments = []

--- a/docs/plans/78-multilingual-alignment-speaker-assignment.md
+++ b/docs/plans/78-multilingual-alignment-speaker-assignment.md
@@ -64,4 +64,4 @@ No UI change. Satisfied transitively: `_finalize_aligned` guarantees finite, non
 
 ## Deviations from Plan
 
-_Populated after implementation._
+- None. The implementation followed the approved plan; the only changes from the plan-review negotiation (single-language-per-`align()` invariant, `_finite`/per-group fallback, coarse progress bumps) were already folded into the plan before implementation.

--- a/docs/plans/78-multilingual-alignment-speaker-assignment.md
+++ b/docs/plans/78-multilingual-alignment-speaker-assignment.md
@@ -1,0 +1,67 @@
+# Plan: Per-language alignment & speaker assignment for mixed-language meetings
+
+**Story**: #78
+**Spec**: docs/specs/multilingual-transcription.md
+**Branch**: feature/78-multilingual-alignment-speaker-assignment
+**Date**: 2026-06-10
+**Mode**: Standard — building on the existing mock-heavy transcriber test pattern; tests written alongside the implementation.
+
+## Technical Decisions
+
+### TD-1: Extract a shared `_diarize_and_assign` helper
+- **Context**: The single-language path holds the only diarization + raw-turns-capture + `assign_word_speakers` block (`transcriber.py:301-323`). The multilingual path now needs the identical logic.
+- **Decision**: Extract it into `_diarize_and_assign(job_id, audio, num_speakers, device, result, *, progress=70)` returning `(result_with_speakers, diarize_turns)`; no-op `(result, None)` when `HF_TOKEN` is unset. Both paths call it.
+- **Alternatives considered**: Duplicate the block into the multilingual path — rejected; it would create the 2nd occurrence and trend toward a rule-of-three violation. Extraction keeps single-language behavior identical (same `progress=70`, same raw-turns capture).
+
+### TD-2: Per-language alignment with a single-language-per-`align()`-call invariant
+- **Context**: `whisperx.align` is language-specific. It also **sentence-splits** input segments (output count != input count) and re-builds segment dicts.
+- **Decision**: Group segments by detected language and call `whisperx.align` **once per group**. Because each call receives one language's segments, language is re-attached as a **constant** to every returned segment — never positionally zipped. This makes the count mismatch from sentence-splitting harmless and keeps BR-8 (each segment aligned with its own language's model) provably correct.
+- **Alternatives considered**: Align all segments in one call and zip language back positionally — rejected; sentence-splitting breaks the 1:1 assumption and would mis-assign languages.
+
+### TD-3: Text-preserving, finite-timestamp guarantees
+- **Context**: `whisperx.align` can fail internally (it appends the original segment with `words=[]`), the model can fail to load, and interpolation can leave residual NaN.
+- **Decision**: Wrap each group's alignment in `try/except`; on any exception fall back to segment-level timestamps (`_segment_level`, text copied verbatim). Guard empty align output the same way. Run every aligned segment through `_finalize_aligned`, which uses `_finite` to coerce non-finite start/end to a running `last_end` fallback and clamps `end >= start`, yielding finite, non-decreasing timestamps. This satisfies Truth-2 (a missing/failed alignment degrades only timing, never text) for both the "no model configured" and "model present but align failed" cases.
+- **Alternatives considered**: Drop NaN/failed segments — rejected; loses transcript text (violates Truth-2).
+
+### TD-4: Coarse progress bumps instead of callback rescaling
+- **Context**: `transcribe_multilingual` emits progress up to ~88; alignment + diarization need headroom below the `saving` stage at 90.
+- **Decision**: Lower the transcribe cap from `min(pct, 89)` to `min(pct, 80)` inside the `progress_cb`, then fixed bumps — `aligning` at 82, diarize via `_diarize_and_assign(progress=85)`. No rescale arithmetic.
+- **Alternatives considered**: Rescale the 20->88 emission into 20->65 — rejected as needless arithmetic with no AC benefit (Architect Minor).
+
+## Files to Create or Modify
+
+- `backend/services/transcriber.py` — add `_finite`, `_segment_level`, `_finalize_aligned`, `_align_multilingual_segments`, `_diarize_and_assign`; rewire `_run_multilingual_transcription` (now aligns + diarizes, takes `num_speakers`, returns `diarize_turns`); update routing in `_run_transcription`.
+- `tests/unit/test_transcriber.py` — invert the two obsolete multilingual tests; add per-language alignment, fallback, NaN-repair, unsupported-language, and no-HF_TOKEN tests.
+- `docs/plans/78-multilingual-alignment-speaker-assignment.md` — this plan.
+
+## Approach per AC
+
+### AC1: segments grouped by detected language, each group aligned with that language's model
+`_align_multilingual_segments` groups by `"language"` and calls `whisperx.align` once per supported language with `model_name=CUSTOM_ALIGN_MODELS.get(language)` (Thai custom model, others default). BR-8 holds via the single-language-per-call invariant.
+
+### AC2: segment whose language has no alignment model retains segment-level timestamps, text unaffected (EC-3, BR-9)
+Languages absent from `ALIGNMENT_LANGUAGES` skip `load_align_model` entirely and pass through `_segment_level` — chunk-level start/end, text untouched, no `words` key. The words-less segment still receives a segment-level speaker from `assign_word_speakers` (already proven by the existing single-language unsupported path).
+
+### AC3: clicking a segment jumps to the correct position, highlight tracks
+No UI change. Satisfied transitively: `_finalize_aligned` guarantees finite, non-decreasing timestamps and the final list is sorted by start, so the existing player's seek/highlight logic reads coherent values.
+
+## Commit Sequence
+
+1. Extract `_diarize_and_assign` shared helper (single-language behavior unchanged).
+2. Add `_align_multilingual_segments` + `_finite`/`_segment_level`/`_finalize_aligned`.
+3. Wire alignment + diarization into `_run_multilingual_transcription` + routing.
+4. Tests covering AC1/AC2/AC3, truths, and single-language regression.
+
+## Risks and Trade-offs
+
+- `whisperx.align` count/NaN/failure variance — mitigated by count-agnostic iteration, `_finite` repair, and per-group fallback.
+- Refactoring the working single-language diarization — mitigated by keeping `progress=70` and asserting `diarize_turns` content is preserved.
+- Loading multiple alignment models per meeting increases processing time/memory — accepted per spec OQ-2 (any increase acceptable provided single-language meetings are unaffected).
+
+## Deviations from Spec
+
+- None.
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 
 from backend.schemas import AudioAnalysis, AudioAnalysisStatus, JobStatus, MeetingStatus
 from backend.services.job_queue import JobQueue
-from backend.services.transcriber import _get_device, _is_cancelled, _run_audio_analysis
+from backend.services.transcriber import (
+    _align_multilingual_segments,
+    _get_device,
+    _is_cancelled,
+    _run_audio_analysis,
+)
 
 
 def _create_test_audio(path: Path) -> None:
@@ -796,13 +801,43 @@ class TestTranscriptionRouting:
         assert mw.load_model.call_args.kwargs.get("language") is None
         assert "language" not in mw.load_model.return_value.transcribe.call_args.kwargs
 
+    @staticmethod
+    def _ml_mocks():
+        """Mocks for the multilingual path: align echoes its input segments and
+        assign_word_speakers stamps a speaker while preserving the language tag."""
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_audio.return_value = MagicMock()
+        mock_whisperx.load_model.return_value = MagicMock()
+        mock_whisperx.load_align_model.return_value = (MagicMock(), MagicMock())
+        # align sentence-splits in reality; here it echoes each input segment so the
+        # per-language grouping (one call per language) stays observable.
+        mock_whisperx.align.side_effect = lambda segs, *a, **k: {"segments": [dict(s) for s in segs]}
+
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+
+        diarize_df = MagicMock()
+        diarize_df.iterrows.return_value = [(0, {"start": 0.0, "end": 9.0, "speaker": "SPEAKER_00"})]
+        diarize_df.__len__.return_value = 1
+        # The pipeline instance is callable; calling it (diarize_model(audio)) yields the dataframe.
+        diarize_instance = MagicMock(return_value=diarize_df)
+        mock_diarize_cls = MagicMock(return_value=diarize_instance)
+
+        def _assign(_diarize_df, result):
+            for seg in result["segments"]:
+                seg["speaker"] = "SPEAKER_00"
+            return result
+
+        return mock_whisperx, mock_torch, mock_diarize_cls, MagicMock(side_effect=_assign)
+
     @patch("backend.services.transcriber.WHISPER_BATCH_SIZE", 16)
     @patch("backend.services.transcriber.WHISPER_MODEL", "large-v3")
     @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
     @patch("backend.services.transcriber.HF_TOKEN", "test-token")
-    def test_two_languages_run_multilingual_path(self, tmp_path: Path):
-        """Two+ expected languages → multilingual path, no align, no diarize, per-segment language."""
-        mw, mt, mdc, ma = self._mocks()
+    def test_two_languages_align_diarize_and_preserve_language(self, tmp_path: Path):
+        """Two+ expected languages → multilingual path now aligns, diarizes, assigns
+        speakers, and preserves each segment's detected language (BR-8, AC1)."""
+        mw, mt, mdc, ma = self._ml_mocks()
         queue = JobQueue()
         meetings_dir = tmp_path / "meetings"
         meeting_dir = _create_meeting_on_disk(meetings_dir, language="auto", expected_languages=["en", "th"])
@@ -830,22 +865,25 @@ class TestTranscriptionRouting:
         ml.assert_called_once()
         # Multilingual loads the model without a fixed language.
         assert "language" not in mw.load_model.call_args.kwargs
-        # No alignment and no diarization in this slice.
-        mw.align.assert_not_called()
-        mdc.assert_not_called()
+        # Alignment runs once per language group (en, th) with each language's own model (BR-8).
+        align_languages = sorted(c.kwargs["language_code"] for c in mw.load_align_model.call_args_list)
+        assert align_languages == ["en", "th"]
+        # Diarization now runs on the multilingual path.
+        mdc.assert_called_once()
 
         transcript = json.loads((meeting_dir / "transcript.json").read_text())
-        assert [s["language"] for s in transcript["segments"]] == ["en", "th"]
-        assert all(s["speaker"] == "UNKNOWN" for s in transcript["segments"])
+        assert {s["language"] for s in transcript["segments"]} == {"en", "th"}
+        assert all(s["speaker"] == "SPEAKER_00" for s in transcript["segments"])
         assert transcript["language"] == "en"  # dominant
 
     @patch("backend.services.transcriber.WHISPER_BATCH_SIZE", 16)
     @patch("backend.services.transcriber.WHISPER_MODEL", "large-v3")
     @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
     @patch("backend.services.transcriber.HF_TOKEN", "test-token")
-    def test_multilingual_audio_analysis_gets_dominant_and_no_turns(self, tmp_path: Path):
-        """Audio analysis on the multilingual path receives the dominant language and no diarize turns."""
-        mw, mt, mdc, ma = self._mocks()
+    def test_multilingual_audio_analysis_gets_dominant_and_turns(self, tmp_path: Path):
+        """Audio analysis on the multilingual path receives the dominant language and
+        the diarization turns captured during speaker assignment."""
+        mw, mt, mdc, ma = self._ml_mocks()
         queue = JobQueue()
         meetings_dir = tmp_path / "meetings"
         _create_meeting_on_disk(
@@ -871,4 +909,165 @@ class TestTranscriptionRouting:
         maa.assert_called_once()
         # detected_language is the 4th positional arg; diarize_turns is a kwarg.
         assert maa.call_args.args[3] == "en"
-        assert maa.call_args.kwargs["diarize_turns"] is None
+        assert maa.call_args.kwargs["diarize_turns"] == [(0.0, 9.0, "SPEAKER_00")]
+
+    @patch("backend.services.transcriber.WHISPER_BATCH_SIZE", 16)
+    @patch("backend.services.transcriber.WHISPER_MODEL", "large-v3")
+    @patch("backend.services.transcriber.WHISPER_DEVICE", "cpu")
+    @patch("backend.services.transcriber.HF_TOKEN", "")
+    def test_multilingual_without_hf_token_completes_unknown_speakers(self, tmp_path: Path):
+        """Multilingual path with no HF_TOKEN still aligns and completes; diarization
+        is skipped so segments keep UNKNOWN speakers (no crash)."""
+        mw, mt, mdc, ma = self._ml_mocks()
+        queue = JobQueue()
+        meetings_dir = tmp_path / "meetings"
+        meeting_dir = _create_meeting_on_disk(meetings_dir, language="auto", expected_languages=["en", "th"])
+        job = queue.create_job("test-meeting")
+        ml = MagicMock(
+            return_value=(
+                [
+                    {"start": 0.0, "end": 2.0, "text": "Hello", "language": "en"},
+                    {"start": 2.0, "end": 4.0, "text": "สวัสดี", "language": "th"},
+                ],
+                "en",
+            )
+        )
+
+        with (
+            patch("backend.services.transcriber.MEETINGS_DIR", meetings_dir),
+            patch("backend.services.transcriber.job_queue", queue),
+            patch("backend.services.transcriber.transcribe_multilingual", ml),
+            patch.dict("sys.modules", self._sys_modules(mw, mt, mdc, ma)),
+        ):
+            from backend.services.transcriber import _run_transcription
+
+            _run_transcription("test-meeting", job.id)
+
+        mdc.assert_not_called()
+        transcript = json.loads((meeting_dir / "transcript.json").read_text())
+        assert all(s["speaker"] == "UNKNOWN" for s in transcript["segments"])
+        assert {s["language"] for s in transcript["segments"]} == {"en", "th"}
+
+
+def _fake_whisperx(align_side_effect):
+    """Build a mock whisperx module for direct _align_multilingual_segments tests."""
+    mw = MagicMock()
+    mw.load_align_model.return_value = (MagicMock(), MagicMock())
+    mw.align.side_effect = align_side_effect
+    return mw
+
+
+def _echo_align(segs, *args, **kwargs):
+    """Stand in for whisperx.align: echo each input segment unchanged."""
+    return {"segments": [dict(s) for s in segs]}
+
+
+class TestAlignMultilingualSegments:
+    """Per-language alignment grouping, fallback, and timestamp repair (BR-8, BR-9, EC-3)."""
+
+    @staticmethod
+    def _run(ml_segments, align_side_effect):
+        mw = _fake_whisperx(align_side_effect)
+        with patch.dict("sys.modules", {"whisperx": mw, "torch": MagicMock()}):
+            result = _align_multilingual_segments(ml_segments, MagicMock(), "cpu")
+        return result, mw
+
+    def test_each_language_aligned_with_its_own_model(self):
+        """BR-8: one align model per detected language; Thai uses the custom model."""
+        ml = [
+            {"start": 0.0, "end": 2.0, "text": "Hello", "language": "en"},
+            {"start": 2.0, "end": 4.0, "text": "สวัสดี", "language": "th"},
+        ]
+        _result, mw = self._run(ml, _echo_align)
+
+        calls = {c.kwargs["language_code"]: c.kwargs["model_name"] for c in mw.load_align_model.call_args_list}
+        assert calls["en"] is None
+        assert calls["th"] == "airesearch/wav2vec2-large-xlsr-53-th"
+
+    def test_segments_grouped_by_language(self):
+        """Segments of the same language are aligned together in a single call."""
+        ml = [
+            {"start": 0.0, "end": 1.0, "text": "Hello", "language": "en"},
+            {"start": 1.0, "end": 2.0, "text": "สวัสดี", "language": "th"},
+            {"start": 2.0, "end": 3.0, "text": "Bye", "language": "en"},
+        ]
+        _result, mw = self._run(ml, _echo_align)
+
+        # Two align calls (one per language), the English call carrying both English segments.
+        assert mw.align.call_count == 2
+        en_call = next(c for c in mw.align.call_args_list if len(c.args[0]) == 2)
+        assert [s["text"] for s in en_call.args[0]] == ["Hello", "Bye"]
+
+    def test_sentence_split_retains_all_segments(self):
+        """align may return MORE segments than it was given (sentence-splitting); all are kept and tagged."""
+
+        def split(segs, *args, **kwargs):
+            return {
+                "segments": [
+                    {"start": 0.0, "end": 1.0, "text": "Hello"},
+                    {"start": 1.0, "end": 2.0, "text": "there"},
+                ]
+            }
+
+        ml = [{"start": 0.0, "end": 2.0, "text": "Hello there", "language": "en"}]
+        result, _mw = self._run(ml, split)
+
+        assert len(result) == 2
+        assert all(s["language"] == "en" for s in result)
+
+    def test_align_failure_falls_back_to_segment_level(self):
+        """Truth-2: a configured model that fails to align degrades timing only — text is preserved."""
+
+        def boom(segs, *args, **kwargs):
+            raise RuntimeError("alignment exploded")
+
+        ml = [{"start": 1.0, "end": 3.0, "text": "Hello", "language": "en"}]
+        result, _mw = self._run(ml, boom)
+
+        assert len(result) == 1
+        assert result[0]["text"] == "Hello"
+        assert result[0]["start"] == 1.0
+        assert result[0]["end"] == 3.0
+        assert "words" not in result[0]
+
+    def test_non_finite_timestamps_repaired(self):
+        """NaN/inf timestamps from alignment are repaired so click-to-seek stays deterministic (AC3)."""
+
+        def nan_align(segs, *args, **kwargs):
+            return {"segments": [{"start": float("nan"), "end": float("inf"), "text": "Hello", "words": []}]}
+
+        ml = [{"start": 5.0, "end": 7.0, "text": "Hello", "language": "en"}]
+        result, _mw = self._run(ml, nan_align)
+
+        # Non-finite start falls back to the group's first start; end clamps to >= start.
+        assert result[0]["start"] == 5.0
+        assert result[0]["end"] == 5.0
+
+    def test_unsupported_language_skips_alignment_and_keeps_segment_level(self):
+        """AC2/EC-3/BR-9: a language with no alignment model is never sent to load_align_model;
+        its segment retains chunk-level timestamps, unchanged text, and no word data."""
+        ml = [
+            {"start": 0.0, "end": 2.0, "text": "Hello", "language": "en"},
+            {"start": 2.0, "end": 4.0, "text": "xin chào", "language": "xx"},
+        ]
+        result, mw = self._run(ml, _echo_align)
+
+        aligned_languages = [c.kwargs["language_code"] for c in mw.load_align_model.call_args_list]
+        assert "xx" not in aligned_languages
+
+        xx_seg = next(s for s in result if s["language"] == "xx")
+        assert xx_seg["start"] == 2.0
+        assert xx_seg["end"] == 4.0
+        assert xx_seg["text"] == "xin chào"
+        assert "words" not in xx_seg  # words-less segment still survives downstream diarization
+
+    def test_output_sorted_by_start(self):
+        """The merged cross-language result is ordered by start time (AC3)."""
+        ml = [
+            {"start": 4.0, "end": 6.0, "text": "later", "language": "th"},
+            {"start": 0.0, "end": 2.0, "text": "first", "language": "en"},
+        ]
+        result, _mw = self._run(ml, _echo_align)
+
+        starts = [s["start"] for s in result]
+        assert starts == sorted(starts)


### PR DESCRIPTION
Closes [#78](https://github.com/nimblehq/audio-transcriber/issues/78)

## Summary

Mixed-language meetings (2+ expected languages, introduced in #77) were transcribed per chunk but skipped both word-level alignment and diarization — every segment kept chunk-level timestamps and an `UNKNOWN` speaker. This PR wires the multilingual path into per-language alignment and the existing speaker-assignment stage, so timestamps and speaker credit stay accurate across language switches.

- Segments are grouped by their detected language and each group is aligned with that language's own model (`ALIGNMENT_LANGUAGES` / `CUSTOM_ALIGN_MODELS`, including the configured Thai model) — BR-8, AC1.
- A segment whose detected language has no alignment model retains chunk-level timestamps with its text untouched (BR-9, EC-3, AC2).
- Word-level timestamps feed the existing PyAnnote diarization / `assign_word_speakers`, so the right speaker is credited and clicking any passage (in either language) seeks correctly in the existing player — AC3, no UI change.

## Approach

- **Extracted `_diarize_and_assign`** so the single-language and multilingual paths share one diarization + raw-turns-capture + speaker-assignment implementation (single-language behavior unchanged).
- **Added `_align_multilingual_segments`** which calls `whisperx.align` once per detected language. Because `whisperx.align` sentence-splits (output count ≠ input), language is re-attached as a per-call constant rather than positionally zipped — keeping BR-8 provably correct.
- **Graceful degradation (Truth-2):** a missing alignment model or an alignment failure falls back to segment-level timestamps with text copied verbatim; non-finite timestamps from alignment are repaired so click-to-seek stays deterministic.
- Progress reporting on the multilingual path was rebalanced (transcribe capped at 80) to leave room for the aligning/diarizing stages.

Design decisions and the two-iteration architect plan review are recorded in `docs/plans/78-multilingual-alignment-speaker-assignment.md`. Spec: `docs/specs/multilingual-transcription.md`.

## Verification

- `pytest tests/` — **302 passed**.
- `transcriber.py` coverage **89%** (target 80%).
- `ruff check` + `ruff format --check` clean.
- New/updated tests cover: per-language model selection (Thai custom model), language grouping, sentence-split retention, align-failure fallback, NaN/inf timestamp repair, unsupported-language segment-level path (no `words` key, survives diarization), sorted output, multilingual diarization + speaker assignment, and multilingual completion without `HF_TOKEN`.
- Architect plan review passed (iteration 2) and architect code review approved with no Critical/Major findings.
