### PR TITLE
[#79] See which language each segment was detected as

### DIFF
--- a/docs/plans/79-per-segment-language-badge.md
+++ b/docs/plans/79-per-segment-language-badge.md
@@ -53,4 +53,4 @@ Badge lives in `.segment-header`, not `.segment-text`. `renderPlainTextTab` read
 
 ## Deviations from Plan
 
-_Populated after implementation._
+- None. Implementation followed the approved plan exactly: shared `LANGUAGE_NAMES` map + `formatLanguageName` in utils.js, upload.js options generated from the map, `renderLanguageBadge` in the transcript viewer, and `.language-badge` CSS. Architect code review passed with no Critical/Major findings.

--- a/docs/plans/79-per-segment-language-badge.md
+++ b/docs/plans/79-per-segment-language-badge.md
@@ -1,0 +1,56 @@
+# Plan: See which language each segment was detected as
+
+**Story**: 79
+**Spec**: docs/specs/multilingual-transcription.md
+**Branch**: feature/79-per-segment-language-badge
+**Date**: 2026-06-10
+**Mode**: Standard — no JS test harness exists (vanilla JS, `package.json` is release-tooling only, conventions state "No frontend linter/test"); ACs verified via manual run + QA agent.
+
+## Technical Decisions
+
+### TD-1: Single source of truth for language code → display name
+- **Context**: A code→name mapping already exists implicitly as 18 hardcoded `<option>` entries in `upload.js`. The badge needs the same mapping. The Architect's first review caught that duplicating only `en`/`th` would fail AC1 for the 16 other selectable languages.
+- **Decision**: Add `LANGUAGE_NAMES` (all 18 codes) and `formatLanguageName(code)` to `utils.js`, and have `upload.js` render its `<option>` list from that map. One authoritative representation; no drift.
+- **Alternatives considered**: (a) Duplicate a full 18-entry map in both places with sync comments — rejected, drift-prone (it already drifted once). (b) Map only en/th — rejected, fails AC1 for other languages.
+
+### TD-2: Honest fallback title for EC-8
+- **Context**: Legacy/un-analyzed segments have no per-segment language and fall back to the meeting primary (default `"en"`). Presenting that as a definite per-segment detection would overstate confidence.
+- **Decision**: Badge text is the resolved language name either way (truth: badge names the segment's language, falling back to meeting language). The `title` tooltip distinguishes `Detected language: {name}` (segment carries its own language) from `Meeting language: {name}` (EC-8 fallback).
+- **Alternatives considered**: Mute the badge visually (emotion-badge-muted precedent) — deferred as unnecessary visual noise; the title distinction is enough.
+
+## Files to Create or Modify
+
+- `frontend/js/utils.js` — add `LANGUAGE_NAMES` (18 codes) + `formatLanguageName(code)` (mapped name, else uppercased code for unknown non-empty code, else `''`).
+- `frontend/js/components/upload.js` — generate the language `<option>` list from `LANGUAGE_NAMES` (insertion order preserves en/th-first ordering).
+- `frontend/js/components/transcript-viewer.js` — render a per-segment `.language-badge` in `.segment-header` after the speaker label; resolve `seg.language || transcript.language`; escapeHtml text + title.
+- `frontend/css/styles.css` — add `.language-badge` styled like `.emotion-badge` (outlined pill, theme vars).
+
+## Approach per AC
+
+### AC1: Each segment header shows a badge naming the segment's detected language.
+Compute `meetingLanguage = transcript.language` once in `renderSegments`; per segment `segLang = seg.language || meetingLanguage`, `langName = formatLanguageName(segLang)`. Render the badge when `langName` is non-empty. All 18 selectable languages map to a name; unknown codes degrade to the uppercased code.
+
+### AC2: Legacy segment with no stored language falls back to the meeting's primary detected language (EC-8).
+`seg.language === null` → `transcript.language` (the meeting primary). No metadata migration.
+
+### AC3: Copy/export output unchanged — badge not in copied text (OQ-5).
+Badge lives in `.segment-header`, not `.segment-text`. `renderPlainTextTab` reads only `.segment-time` / `.speaker-label` / `.segment-text`, so it never picks up the badge. No copy-logic change.
+
+## Commit Sequence
+
+1. Add shared `LANGUAGE_NAMES` map + `formatLanguageName` to utils.js; render upload.js options from it.
+2. Render per-segment language badge in transcript viewer + CSS.
+
+## Risks and Trade-offs
+
+- Unknown/future language codes degrade gracefully to the uppercased code rather than failing.
+- EC-8 fallback presents the meeting primary (default `"en"`) for legacy/un-analyzed segments; the title says "Meeting language:" to avoid asserting a per-segment detection that never happened.
+- `upload.js` option generation is a low-risk render change; ordering preserved via object insertion order.
+
+## Deviations from Spec
+
+- None. Badge is UI-only (OQ-5), defaults to meeting primary for legacy segments (EC-8), and reflects per-segment stored language (BR-12).
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1010,6 +1010,18 @@ body {
     font-style: italic;
 }
 
+.language-badge {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 500;
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    white-space: nowrap;
+}
+
 .prosody-indicator {
     display: inline-flex;
     align-items: end;

--- a/frontend/js/components/transcript-viewer.js
+++ b/frontend/js/components/transcript-viewer.js
@@ -218,6 +218,10 @@ function renderSegments(container, transcript, meta, meetingId, audioAnalysis) {
     const showInsights = AudioInsights.hasCompletedAnalysis(meta, audioAnalysis);
     const insightsBySegment = showInsights ? AudioInsights.indexBySegment(audioAnalysis) : {};
 
+    // Meeting's primary detected language; legacy/single-language segments that
+    // carry no per-segment language fall back to it for the badge (EC-8).
+    const meetingLanguage = transcript.language;
+
     let prevSpeaker = null;
     container.innerHTML = `
         <div class="segments" id="segments-container">
@@ -225,6 +229,7 @@ function renderSegments(container, transcript, meta, meetingId, audioAnalysis) {
                 const speakerName = speakers[seg.speaker] || seg.speaker;
                 const color = speakerColorMap[seg.speaker];
                 const insights = showInsights ? renderSegmentInsights(seg, insightsBySegment[seg.id]) : '';
+                const languageBadge = renderLanguageBadge(seg, meetingLanguage);
                 const isContinuation = seg.speaker === prevSpeaker;
                 prevSpeaker = seg.speaker;
                 return `
@@ -235,6 +240,7 @@ function renderSegments(container, transcript, meta, meetingId, audioAnalysis) {
                                 onclick="handleSpeakerClick(this, '${seg.speaker}', '${seg.id}')">
                                 ${escapeHtml(speakerName)}<svg class="speaker-label-chevron" width="8" height="6" viewBox="0 0 8 6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M1 1.5 L4 4.5 L7 1.5"/></svg>
                             </button>
+                            ${languageBadge}
                             ${insights}
                             <button class="btn btn-icon btn-segment-play" onclick="playFromSegment(${seg.start})" title="Play from here">▶</button>
                         </div>
@@ -244,6 +250,21 @@ function renderSegments(container, transcript, meta, meetingId, audioAnalysis) {
             }).join('')}
         </div>
     `;
+}
+
+// Renders a presentational badge naming the segment's detected language.
+// Uses the segment's own stored language when present, otherwise falls back to
+// the meeting's primary detected language (EC-8). The badge is UI-only and is
+// never read by the copy/export path (renderPlainTextTab), so output is
+// unchanged (OQ-5). Omitted entirely when no language can be resolved.
+function renderLanguageBadge(seg, meetingLanguage) {
+    const code = seg.language || meetingLanguage;
+    const name = formatLanguageName(code);
+    if (!name) return '';
+    const title = seg.language
+        ? `Detected language: ${name}`
+        : `Meeting language: ${name}`;
+    return `<span class="language-badge" title="${escapeHtml(title)}">${escapeHtml(name)}</span>`;
 }
 
 function renderSegmentInsights(seg, insights) {

--- a/frontend/js/components/upload.js
+++ b/frontend/js/components/upload.js
@@ -34,24 +34,8 @@ function renderUpload(container) {
             <div class="form-group">
                 <label for="language-select">Expected languages <span class="form-label-optional">— optional</span></label>
                 <select id="language-select" multiple placeholder="Leave empty to auto-detect the language…">
-                    <option value="en">English</option>
-                    <option value="th">Thai</option>
-                    <option value="fr">French</option>
-                    <option value="de">German</option>
-                    <option value="es">Spanish</option>
-                    <option value="it">Italian</option>
-                    <option value="pt">Portuguese</option>
-                    <option value="nl">Dutch</option>
-                    <option value="ja">Japanese</option>
-                    <option value="zh">Chinese</option>
-                    <option value="ko">Korean</option>
-                    <option value="ru">Russian</option>
-                    <option value="ar">Arabic</option>
-                    <option value="hi">Hindi</option>
-                    <option value="tr">Turkish</option>
-                    <option value="pl">Polish</option>
-                    <option value="vi">Vietnamese</option>
-                    <option value="id">Indonesian</option>
+                    ${Object.entries(LANGUAGE_NAMES).map(([code, name]) =>
+                        `<option value="${code}">${escapeHtml(name)}</option>`).join('')}
                 </select>
                 <p class="language-mode" id="language-mode"></p>
             </div>

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -19,6 +19,39 @@ function formatDate(dateStr) {
     return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
+// Single source of truth for language code -> display name. The upload form
+// builds its expected-language options from this map, and the transcript view
+// renders per-segment language badges from it. Insertion order is the order
+// shown in the upload dropdown (English/Thai first as the primary use case).
+const LANGUAGE_NAMES = {
+    en: 'English',
+    th: 'Thai',
+    fr: 'French',
+    de: 'German',
+    es: 'Spanish',
+    it: 'Italian',
+    pt: 'Portuguese',
+    nl: 'Dutch',
+    ja: 'Japanese',
+    zh: 'Chinese',
+    ko: 'Korean',
+    ru: 'Russian',
+    ar: 'Arabic',
+    hi: 'Hindi',
+    tr: 'Turkish',
+    pl: 'Polish',
+    vi: 'Vietnamese',
+    id: 'Indonesian',
+};
+
+// Returns a human-readable language name for a code. Unknown but non-empty
+// codes degrade to the uppercased code (e.g. "el" -> "EL"); empty/missing
+// codes return '' so callers can omit the badge entirely.
+function formatLanguageName(code) {
+    if (!code) return '';
+    return LANGUAGE_NAMES[code] || code.toUpperCase();
+}
+
 function showToast(message, type = 'success') {
     const container = document.getElementById('toast-container');
     const toast = document.createElement('div');


### PR DESCRIPTION
Closes [#79](https://github.com/nimblehq/audio-transcriber/issues/79)

## Summary

Adds a per-segment language badge to the transcript view so uploaders can quickly spot and judge mis-detected passages in mixed-language meetings. Each segment header now shows a small pill naming the segment's detected language.

- Each segment header renders a badge naming the segment's detected language (BR-12).
- Legacy/single-language segments that carry no per-segment `language` fall back to the meeting's primary detected language (`transcript.language`, EC-8). The badge tooltip distinguishes a per-segment detection ("Detected language: X") from the meeting-level fallback ("Meeting language: X") to avoid overstating confidence.
- The badge is UI-only: copy/export output is unchanged (OQ-5).

## Approach

The badge needs a language-code → display-name mapping that already existed implicitly as 18 hardcoded `<option>` entries in the upload form. Rather than duplicate that data (which would drift), this PR introduces a single source of truth — `LANGUAGE_NAMES` + `formatLanguageName(code)` in `utils.js` — and has both the upload dropdown and the transcript badge consume it. Unknown codes degrade gracefully to the uppercased code; an empty code omits the badge entirely.

The badge lives in `.segment-header` (a sibling of the speaker label), never inside `.segment-text`. `renderPlainTextTab` builds copy/export text by reading only `.segment-time`, `.speaker-label`, and `.segment-text`, so the badge cannot leak into copied output — AC3 holds structurally with no change to the copy path.

`.language-badge` styling mirrors the existing `.emotion-badge` pill (theme-aware via CSS vars). No backend or schema changes — the per-segment `language` field was delivered by #77.

## Verification

- Architect plan review: passed (iteration 2). The first pass caught that the language set is 18 languages, not 2; the map was expanded to cover all of them and made the single source of truth.
- Architect code review: passed with no Critical/Major findings.
- `node --check` on all three modified JS files: passes.
- Manual verification: load a meeting transcript and confirm each segment shows a language badge; confirm legacy segments fall back to the meeting language; confirm "Copy to clipboard" on the Plain Text tab produces output without the badge.