### PR TITLE
[#80] Get emotion results for English portions of mixed-language meetings

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -63,6 +63,11 @@ class EmotionAnnotation(BaseModel):
     low_confidence: bool
 
 
+class EmotionUnavailable(BaseModel):
+    segment_id: str
+    reason: str
+
+
 class ProsodyAnnotation(BaseModel):
     segment_id: str
     speaker: str
@@ -110,6 +115,9 @@ class AudioAnalysis(BaseModel):
     emotion_status: AudioAnalysisStatus | None = None
     emotion_reason: str | None = None
     emotions: list[EmotionAnnotation] = Field(default_factory=list)
+    # Per-segment markers for segments whose language the emotion (SER) model does
+    # not support (BR-10). Data-only, mirroring prosody_unavailable.
+    emotion_unavailable: list[EmotionUnavailable] = Field(default_factory=list)
     prosody_status: AudioAnalysisStatus | None = None
     prosody_reason: str | None = None
     prosody: list[ProsodyAnnotation] = Field(default_factory=list)

--- a/backend/services/emotion_analyzer.py
+++ b/backend/services/emotion_analyzer.py
@@ -10,6 +10,10 @@ from backend.schemas import EmotionAnnotation, EmotionCategory
 logger = logging.getLogger(__name__)
 
 LOW_CONFIDENCE_THRESHOLD = 0.5
+# Languages the SER model is validated for. Single source of truth for emotion
+# gating; non-English segments are marked unavailable rather than mislabeled
+# (BR-10, OQ-4 — a non-English emotion model is out of scope).
+SUPPORTED_LANGUAGES = frozenset({"en"})
 SER_MODEL_ID = "firdhokk/speech-emotion-recognition-with-openai-whisper-large-v3"
 SAMPLE_RATE = 16000
 MIN_SEGMENT_SECONDS = 0.3

--- a/backend/services/transcriber.py
+++ b/backend/services/transcriber.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from backend.schemas import (
     AudioAnalysis,
     AudioAnalysisStatus,
+    EmotionUnavailable,
     JobStatus,
     MeetingMetadata,
     MeetingStatus,
@@ -139,22 +140,41 @@ def _run_emotion_analysis(
     audio,
     segment_models: list[TranscriptSegment],
     detected_language: str,
-) -> tuple[AudioAnalysisStatus, str | None, list]:
-    """Run SER. Returns (status, reason, annotations)."""
-    if detected_language != "en":
-        logger.info("Skipping emotion analysis: language %s is not supported", detected_language)
-        return AudioAnalysisStatus.UNAVAILABLE, f"language_not_supported:{detected_language}", []
+) -> tuple[AudioAnalysisStatus, str | None, list, list[EmotionUnavailable]]:
+    """Run SER per segment, gated on each segment's language (BR-10).
+
+    English segments are analyzed; segments in a language the emotion model does
+    not support are marked unavailable. The meeting is no longer skipped wholesale
+    when it merely contains some non-English speech (EC-6). A segment with no
+    per-segment language (single-language path, pre-feature transcripts) falls
+    back to the meeting's detected language (EC-8).
+
+    Returns (status, reason, annotations, unavailable_markers).
+    """
+    from backend.services.emotion_analyzer import SUPPORTED_LANGUAGES, analyze_segments
+
+    supported: list[TranscriptSegment] = []
+    unavailable: list[EmotionUnavailable] = []
+    for segment in segment_models:
+        language = segment.language or detected_language
+        if language in SUPPORTED_LANGUAGES:
+            supported.append(segment)
+        else:
+            unavailable.append(EmotionUnavailable(segment_id=segment.id, reason=f"language_not_supported:{language}"))
+
+    if not supported:
+        languages = ",".join(sorted({m.reason.split(":", 1)[1] for m in unavailable}))
+        logger.info("Skipping emotion analysis: no emotion-supported segments (languages: %s)", languages)
+        return AudioAnalysisStatus.UNAVAILABLE, f"language_not_supported:{languages}", [], unavailable
 
     try:
         job_queue.update_job(job_id, stage="emotion_analysis", progress=92)
 
-        from backend.services.emotion_analyzer import analyze_segments
-
-        annotations = analyze_segments(audio_path=None, segments=segment_models, audio_array=audio)
-        return AudioAnalysisStatus.COMPLETED, None, annotations
+        annotations = analyze_segments(audio_path=None, segments=supported, audio_array=audio)
+        return AudioAnalysisStatus.COMPLETED, None, annotations, unavailable
     except Exception as e:
         logger.exception("Emotion analysis failed")
-        return AudioAnalysisStatus.FAILED, str(e), []
+        return AudioAnalysisStatus.FAILED, str(e), [], unavailable
 
 
 def _run_prosody_analysis(
@@ -236,7 +256,9 @@ def _run_audio_analysis(
     """
     segment_models = [TranscriptSegment(**s) for s in segments]
 
-    emotion_status, emotion_reason, emotions = _run_emotion_analysis(job_id, audio, segment_models, detected_language)
+    emotion_status, emotion_reason, emotions, emotion_unavailable = _run_emotion_analysis(
+        job_id, audio, segment_models, detected_language
+    )
     prosody_status, prosody_reason, prosody, prosody_unavailable = _run_prosody_analysis(job_id, audio, segment_models)
     (
         interaction_status,
@@ -257,6 +279,7 @@ def _run_audio_analysis(
         emotion_status=emotion_status,
         emotion_reason=emotion_reason,
         emotions=emotions,
+        emotion_unavailable=emotion_unavailable,
         prosody_status=prosody_status,
         prosody_reason=prosody_reason,
         prosody=prosody,

--- a/docs/plans/80-multilingual-emotion-per-segment.md
+++ b/docs/plans/80-multilingual-emotion-per-segment.md
@@ -61,4 +61,4 @@ Empty supported list → `UNAVAILABLE` (never `FAILED`), reason `language_not_su
 
 ## Deviations from Plan
 
-_Populated after implementation._
+- None. Implemented as planned across three commits. Architect plan review and code review both passed.

--- a/docs/plans/80-multilingual-emotion-per-segment.md
+++ b/docs/plans/80-multilingual-emotion-per-segment.md
@@ -1,0 +1,64 @@
+# Plan: Per-segment emotion gating for mixed-language meetings
+
+**Story**: 80
+**Spec**: docs/specs/multilingual-transcription.md
+**Branch**: feature/80-multilingual-emotion-per-segment
+**Date**: 2026-06-10
+**Mode**: TDD — pure partition logic with clear inputs/outputs and an existing test harness (`TestRunAudioAnalysis`).
+
+## Technical Decisions
+
+### TD-1: Per-segment gating lives in `_run_emotion_analysis`, not the analyzer
+- **Context**: The whole-meeting gate (`detected_language != "en"`) must become per-segment. The gate could live in the analyzer or the transcriber call site.
+- **Decision**: Keep the gate in `transcriber._run_emotion_analysis` (the slice scope says "replace the gate in that function"). The analyzer stays generic — it classifies whatever segments it is given.
+- **Alternatives considered**: Pushing language awareness into `emotion_analyzer.analyze_segments` and its `_Segment` protocol — rejected as wider blast radius and the analyzer's protocol has no `language`.
+
+### TD-2: `SUPPORTED_LANGUAGES` constant owned by the emotion analyzer
+- **Context**: "en" was hardcoded in the gate. Need a single source of truth.
+- **Decision**: `SUPPORTED_LANGUAGES = frozenset({"en"})` in `emotion_analyzer.py` (the model is the authority on what it supports); imported by the transcriber.
+- **Alternatives considered**: Constant in transcriber — rejected; analyzer is the right home. Thai SER model is explicitly out of scope (OQ-4).
+
+### TD-3: Mirror the prosody unavailable-marker pattern
+- **Context**: "Non-English segments are marked unavailable." Prosody already has `ProsodyUnavailable` + `AudioAnalysis.prosody_unavailable` (data-only markers, never rendered).
+- **Decision**: Add `EmotionUnavailable(segment_id, reason)` and `AudioAnalysis.emotion_unavailable`. Frontend needs no badge work (no-annotation → no-badge is already graceful).
+
+### TD-4: Effective-language fallback for EC-8 backward compatibility
+- **Context**: Single-language and pre-feature segments carry `language=None`.
+- **Decision**: Effective language `lang = seg.language or detected_language`. This preserves today's behavior: an English single-language meeting analyzes every segment; a French one marks every segment unavailable with reason `language_not_supported:fr`.
+
+## Files to Create or Modify
+
+- `backend/services/emotion_analyzer.py` — add `SUPPORTED_LANGUAGES = frozenset({"en"})`.
+- `backend/schemas.py` — add `EmotionUnavailable` model; add `emotion_unavailable` field to `AudioAnalysis`.
+- `backend/services/transcriber.py` — rewrite `_run_emotion_analysis` (4-tuple return with per-segment markers); update `_run_audio_analysis` to unpack and populate `emotion_unavailable`.
+- `frontend/js/components/upload.js` — correct the disclosure copy.
+- `tests/unit/test_transcriber.py`, `tests/unit/test_schemas.py` — coverage.
+
+## Approach per AC
+
+### AC 1: English segments annotated, non-English marked unavailable, meeting not skipped
+Partition `segment_models` by effective language. Supported → analyzed subset; unsupported → `EmotionUnavailable`. Non-empty supported list → `analyze_segments(subset)` → `COMPLETED` + markers. The analyzer slices audio by absolute `start/end`, so a subset over the full audio array is safe.
+
+### AC 2: No English → unavailable (not failed), prosody and interaction still run
+Empty supported list → `UNAVAILABLE` (never `FAILED`), reason `language_not_supported:<sorted,unique,langs>`. Prosody/interaction untouched; `_roll_up_status` completes overall.
+
+### AC 3: Prosody and interaction identical regardless of per-segment language
+`_run_prosody_analysis` and `_run_interaction_analysis` unchanged.
+
+## Commit Sequence
+
+1. `[#80]` schema (`EmotionUnavailable` + field) and `SUPPORTED_LANGUAGES` constant
+2. `[#80]` per-segment gating in transcriber + tests
+3. `[#80]` upload disclosure copy
+
+## Risks and Trade-offs
+
+- Return-type change to 4-tuple is contained in `transcriber.py`; external tests call `_run_audio_analysis`, not the tuple directly. The FAILED branch still returns its accumulated markers.
+
+## Deviations from Spec
+
+- None.
+
+## Deviations from Plan
+
+_Populated after implementation._

--- a/frontend/js/components/upload.js
+++ b/frontend/js/components/upload.js
@@ -71,8 +71,9 @@ function renderUpload(container) {
                         Adds 8–17 minutes to a 1-hour meeting (roughly +50% processing time).
                     </p>
                     <p class="form-disclosure-note">
-                        Currently optimized for English. Results may be less reliable for other languages,
-                        and analysis is skipped entirely when the detected language isn't supported.
+                        Emotion analysis currently supports English only. In a mixed-language meeting,
+                        the English portions are still analyzed and other-language passages are marked
+                        unavailable. Prosody and interaction signals run for every language.
                     </p>
                 </div>
             </div>

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -10,6 +10,7 @@ from backend.schemas import (
     AudioAnalysisStatus,
     EmotionAnnotation,
     EmotionCategory,
+    EmotionUnavailable,
     InteractionEvent,
     InteractionEventType,
     JobInfo,
@@ -312,6 +313,18 @@ class TestAudioAnalysisFields:
         a = AudioAnalysis(status=AudioAnalysisStatus.UNAVAILABLE, reason="language_not_supported:fr")
         assert a.emotions == []
         assert a.reason == "language_not_supported:fr"
+
+    def test_audio_analysis_default_emotion_unavailable_empty(self):
+        a = AudioAnalysis(status=AudioAnalysisStatus.COMPLETED)
+        assert a.emotion_unavailable == []
+
+    def test_audio_analysis_with_emotion_unavailable(self):
+        a = AudioAnalysis(
+            status=AudioAnalysisStatus.COMPLETED,
+            emotion_unavailable=[EmotionUnavailable(segment_id="seg-1", reason="language_not_supported:th")],
+        )
+        assert a.emotion_unavailable[0].segment_id == "seg-1"
+        assert a.emotion_unavailable[0].reason == "language_not_supported:th"
 
     def test_job_stage_emotion_analysis(self):
         assert JobStage.EMOTION_ANALYSIS == "emotion_analysis"

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -706,6 +706,104 @@ class TestRunAudioAnalysis:
         assert result.segment_interactions[0].followed_by_interruption is True
         assert result.dominant_speaker_limitation is True
 
+    def _mixed_segments(self):
+        return [
+            {"id": "seg_0000", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_00", "text": "hello", "language": "en"},
+            {"id": "seg_0001", "start": 1.0, "end": 2.0, "speaker": "SPEAKER_01", "text": "สวัสดี", "language": "th"},
+        ]
+
+    def test_mixed_meeting_analyzes_english_and_marks_others_unavailable(self):
+        # AC1 / EC-6 / BR-10: English segment analyzed, Thai segment marked unavailable,
+        # meeting not skipped wholesale.
+        captured = {}
+
+        def fake_analyze(audio_path, segments, audio_array=None):
+            captured["segments"] = list(segments)
+            return []
+
+        with patch("backend.services.emotion_analyzer.analyze_segments", side_effect=fake_analyze):
+            with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])):
+                with patch("backend.services.transcriber.job_queue.update_job"):
+                    result = _run_audio_analysis(
+                        job_id="j1",
+                        audio=MagicMock(),
+                        segments=self._mixed_segments(),
+                        detected_language="en",
+                        diarize_turns=self._diarize_turns(),
+                    )
+        # Only the English segment is sent to the SER model.
+        assert [s.id for s in captured["segments"]] == ["seg_0000"]
+        assert result.emotion_status == AudioAnalysisStatus.COMPLETED
+        # The Thai segment is marked unavailable, not dropped silently.
+        assert len(result.emotion_unavailable) == 1
+        assert result.emotion_unavailable[0].segment_id == "seg_0001"
+        assert result.emotion_unavailable[0].reason == "language_not_supported:th"
+        # Prosody + interaction unaffected (AC3 / BR-11).
+        assert result.prosody_status == AudioAnalysisStatus.COMPLETED
+        assert result.interaction_status == AudioAnalysisStatus.COMPLETED
+        assert result.status == AudioAnalysisStatus.COMPLETED
+
+    def test_no_english_segments_reports_unavailable_not_failed(self):
+        # AC2: a meeting with no English segments reports emotion unavailable while
+        # prosody and interaction still run.
+        segments = [
+            {"id": "seg_0000", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_00", "text": "สวัสดี", "language": "th"},
+        ]
+        with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])) as mock_prosody:
+            with patch("backend.services.transcriber.job_queue.update_job"):
+                result = _run_audio_analysis(
+                    job_id="j1",
+                    audio=MagicMock(),
+                    segments=segments,
+                    detected_language="th",
+                    diarize_turns=self._diarize_turns(),
+                )
+        assert result.emotion_status == AudioAnalysisStatus.UNAVAILABLE
+        assert result.emotion_reason == "language_not_supported:th"
+        assert len(result.emotion_unavailable) == 1
+        # Prosody + interaction still run (AC3 / BR-11).
+        assert result.prosody_status == AudioAnalysisStatus.COMPLETED
+        assert result.interaction_status == AudioAnalysisStatus.COMPLETED
+        assert result.status == AudioAnalysisStatus.COMPLETED
+        mock_prosody.assert_called_once()
+
+    def test_no_english_aggregate_reason_lists_languages_sorted(self):
+        # The aggregate reason pins the multi-language format for any future consumer.
+        segments = [
+            {"id": "seg_0000", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_00", "text": "x", "language": "th"},
+            {"id": "seg_0001", "start": 1.0, "end": 2.0, "speaker": "SPEAKER_01", "text": "y", "language": "fr"},
+        ]
+        with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])):
+            with patch("backend.services.transcriber.job_queue.update_job"):
+                result = _run_audio_analysis(
+                    job_id="j1",
+                    audio=MagicMock(),
+                    segments=segments,
+                    detected_language="th",
+                    diarize_turns=self._diarize_turns(),
+                )
+        assert result.emotion_reason == "language_not_supported:fr,th"
+        assert len(result.emotion_unavailable) == 2
+
+    def test_emotion_failure_still_propagates_unavailable_markers(self):
+        # Even when the SER run raises, markers partitioned before the call survive.
+        with patch(
+            "backend.services.emotion_analyzer.analyze_segments",
+            side_effect=RuntimeError("model crashed"),
+        ):
+            with patch("backend.services.prosody_analyzer.analyze_segments", return_value=([], [])):
+                with patch("backend.services.transcriber.job_queue.update_job"):
+                    result = _run_audio_analysis(
+                        job_id="j1",
+                        audio=MagicMock(),
+                        segments=self._mixed_segments(),
+                        detected_language="en",
+                        diarize_turns=self._diarize_turns(),
+                    )
+        assert result.emotion_status == AudioAnalysisStatus.FAILED
+        assert "model crashed" in result.emotion_reason
+        assert [m.segment_id for m in result.emotion_unavailable] == ["seg_0001"]
+
 
 class TestTranscriptionRouting:
     """Routing between single-language and multilingual pipelines (BR-2, BR-3, EC-7)."""


### PR DESCRIPTION
Closes [#80](https://github.com/nimblehq/audio-transcriber/issues/80)

## Summary

Emotion analysis previously gated on the meeting's single detected language, skipping the entire meeting whenever `detected_language != "en"`. For a bilingual (English/Thai) meeting this silently discarded all emotional insight, including the English portions.

This change replaces the whole-meeting gate with **per-segment gating** in `_run_emotion_analysis`:

- English segments are sent to the SER model and receive emotion annotations.
- Segments in a language the emotion model does not support are recorded as `EmotionUnavailable` markers instead of being silently dropped.
- The meeting is no longer skipped wholesale just because it contains some non-English speech (EC-6, BR-10).
- Prosody and interaction analysis remain language-agnostic and untouched (BR-11, AC3).

A segment with no per-segment language (single-language path and pre-feature transcripts) falls back to the meeting's detected language, preserving today's behavior exactly (EC-8).

## Approach

- Added `EmotionUnavailable(segment_id, reason)` to `backend/schemas.py` and an `emotion_unavailable` list on `AudioAnalysis`, mirroring the existing `ProsodyUnavailable` precedent (data-only markers; no new frontend pattern introduced).
- Introduced `SUPPORTED_LANGUAGES = frozenset({"en"})` in `emotion_analyzer.py` as the single source of truth for emotion-supported languages (a non-English SER model is out of scope per OQ-4).
- `_run_emotion_analysis` partitions segments by effective language `seg.language or detected_language`; when no segment is supported it returns `UNAVAILABLE` (never `FAILED`) so prosody and interaction still run (AC2).
- Updated the upload disclosure copy to describe the new partial-analysis behavior.

## Verification

- `pytest tests/unit` — 250 passed (includes new cases: mixed meeting, no-English meeting reports unavailable-not-failed, sorted multi-language aggregate reason, and unavailable markers surviving an SER exception).
- `ruff check` and `ruff format --check` — clean.
- Argus architect plan review and code review both passed with no Critical/Major findings.
